### PR TITLE
feat: Add TSV support and delimiter-aware output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !examples/budget.csv
 dist/
 /result
+/sheets

--- a/internal/sheets/dsv.go
+++ b/internal/sheets/dsv.go
@@ -1,0 +1,27 @@
+package sheets
+
+import (
+	"encoding/csv"
+	"io"
+	"strings"
+)
+
+func delimiterForPath(path string) rune {
+	if strings.HasSuffix(strings.ToLower(path), ".tsv") {
+		return '\t'
+	}
+	return ','
+}
+
+func newDelimitedReader(path string, reader io.Reader) *csv.Reader {
+	csvReader := csv.NewReader(reader)
+	csvReader.FieldsPerRecord = -1
+	csvReader.Comma = delimiterForPath(path)
+	return csvReader
+}
+
+func newDelimitedWriter(path string, writer io.Writer) *csv.Writer {
+	csvWriter := csv.NewWriter(writer)
+	csvWriter.Comma = delimiterForPath(path)
+	return csvWriter
+}

--- a/internal/sheets/main.go
+++ b/internal/sheets/main.go
@@ -299,9 +299,9 @@ func assignmentMatrixForRange(target cellRange, values [][]string) ([][]string, 
 	)
 }
 
-func writeQueryRecords(stdout io.Writer, records [][][]string) error {
+func writeQueryRecords(stdout io.Writer, path string, records [][][]string) error {
 	for _, block := range records {
-		writer := csv.NewWriter(stdout)
+		writer := newDelimitedWriter(path, stdout)
 		if err := writer.WriteAll(block); err != nil {
 			return err
 		}
@@ -425,7 +425,7 @@ func runCLI(args []string, stdout io.Writer) error {
 		}
 	}
 
-	return writeQueryRecords(stdout, queryResults)
+	return writeQueryRecords(stdout, path, queryResults)
 }
 
 func Main(args []string, stdin *os.File, stdout, stderr io.Writer) int {

--- a/internal/sheets/main_test.go
+++ b/internal/sheets/main_test.go
@@ -53,10 +53,12 @@ func TestUpdateQuitsOnCtrlC(t *testing.T) {
 func TestLoadCSVPopulatesSheetAndPreservesFormulas(t *testing.T) {
 	m := newModel()
 	reader := csv.NewReader(strings.NewReader("\"hello,world\",1,=B1+1\nplain,2,\n"))
-
-	if err := m.loadCSV(reader); err != nil {
-		t.Fatalf("expected CSV load to succeed, got %v", err)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("expected CSV read to succeed, got %v", err)
 	}
+
+	m.loadCSV(records)
 
 	assertCellValue(t, m, 0, 0, "hello,world")
 	assertCellValue(t, m, 0, 2, "=B1+1")
@@ -84,6 +86,60 @@ func TestNewProgramModelLoadsCSVFromStdin(t *testing.T) {
 	assertCellValue(t, m, 0, 0, "name")
 	assertCellValue(t, m, 1, 0, "maas")
 	assertCellValue(t, m, 1, 1, "26")
+}
+
+func TestNewProgramModelLoadsTSVFile(t *testing.T) {
+	path := writeTempTSV(t, "data.tsv", "name\tvalue\napples\t3\n")
+
+	m, err := newProgramModel([]string{path})
+	if err != nil {
+		t.Fatalf("expected startup TSV load to succeed, got %v", err)
+	}
+	assertCellValue(t, m, 0, 0, "name")
+	assertCellValue(t, m, 0, 1, "value")
+	assertCellValue(t, m, 1, 0, "apples")
+	assertCellValue(t, m, 1, 1, "3")
+}
+
+func TestRunQueriesTSVFile(t *testing.T) {
+	path := writeTempTSV(t, "data.tsv", "name\tvalue\napples\t3\n")
+	var stdout bytes.Buffer
+
+	if err := run([]string{path, "A2"}, &stdout); err != nil {
+		t.Fatalf("expected TSV cell query to succeed, got %v", err)
+	}
+
+	if got, want := stdout.String(), "apples\n"; got != want {
+		t.Fatalf("expected TSV query output %q, got %q", want, got)
+	}
+}
+
+func TestRunQueriesCellRangeFromTSV(t *testing.T) {
+	path := writeTempTSV(t, "data.tsv", "1\t2\t=A1+B1\n4\t5\t=A2+B2\n")
+	var stdout bytes.Buffer
+
+	if err := run([]string{path, "A1:C2"}, &stdout); err != nil {
+		t.Fatalf("expected TSV range query to succeed, got %v", err)
+	}
+
+	if got, want := stdout.String(), "1\t2\t3\n4\t5\t9\n"; got != want {
+		t.Fatalf("expected TSV range query output %q, got %q", want, got)
+	}
+}
+
+func TestRunAssignsCellValueInTSV(t *testing.T) {
+	path := writeTempTSV(t, "data.tsv", "name\tvalue\napples\t3\n")
+
+	if err := run([]string{path, "B2=20"}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("expected TSV cell assignment to succeed, got %v", err)
+	}
+
+	loaded := newModel()
+	if err := loaded.loadCSVFile(path); err != nil {
+		t.Fatalf("expected written TSV to load, got %v", err)
+	}
+
+	assertCellValue(t, loaded, 1, 1, "20")
 }
 
 func TestResolveInputStreamsUsesStdinOnlyWhenPipedAndNoArgs(t *testing.T) {

--- a/internal/sheets/model.go
+++ b/internal/sheets/model.go
@@ -151,28 +151,28 @@ func (m *model) loadCSVFile(path string) error {
 	}
 	defer file.Close()
 
-	if err := m.loadCSVReader(file); err != nil {
+	records, err := newDelimitedReader(path, file).ReadAll()
+	if err != nil {
 		return err
 	}
+
+	m.loadCSV(records)
 	m.currentFilePath = path
 	return nil
 }
 
 func (m *model) loadCSVReader(reader io.Reader) error {
-	csvReader := csv.NewReader(reader)
-	csvReader.FieldsPerRecord = -1
-	if err := m.loadCSV(csvReader); err != nil {
+	records, err := newDelimitedReader(".csv", reader).ReadAll()
+	if err != nil {
 		return err
 	}
+
+	m.loadCSV(records)
 	m.currentFilePath = ""
 	return nil
 }
 
-func (m *model) loadCSV(reader *csv.Reader) error {
-	records, err := reader.ReadAll()
-	if err != nil {
-		return err
-	}
+func (m *model) loadCSV(records [][]string) error {
 
 	m.cells = make(map[cellKey]string)
 	m.rowCount = defaultRows
@@ -275,8 +275,7 @@ func (m model) writeCSVFile(path string) error {
 	}
 	defer file.Close()
 
-	writer := csv.NewWriter(file)
-	return m.writeCSV(writer)
+	return m.writeCSV(newDelimitedWriter(path, file))
 }
 
 func (m model) Init() tea.Cmd {

--- a/internal/sheets/test_helpers_test.go
+++ b/internal/sheets/test_helpers_test.go
@@ -49,6 +49,17 @@ func writeTempCSV(t *testing.T, relativePath, contents string) string {
 	return path
 }
 
+func writeTempTSV(t *testing.T, relativePath, contents string) string {
+	t.Helper()
+
+	path := tempCSVPath(t, relativePath)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("expected temp TSV write to succeed, got %v", err)
+	}
+
+	return path
+}
+
 func runeKey(value string) tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(value)}
 }


### PR DESCRIPTION
- Introduce a small delimiter helper for CSV and TSV files. 
- Preserve existing CSV load and save behavior while adding TSV support.
- Emit tab-separated query output when the source file is TSV. 
- Add tests for TSV loading, querying, and writing.

resolves #1 