### PR TITLE
feat: sync internal clipboard with system

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/maaslalani/sheets
 go 1.25.7
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/sheets/clipboard.go
+++ b/internal/sheets/clipboard.go
@@ -1,6 +1,10 @@
 package sheets
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"strings"
+	sysclip "github.com/atotto/clipboard"
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 func cloneKeySequence(keys []tea.KeyMsg) []tea.KeyMsg {
 	return append([]tea.KeyMsg(nil), keys...)
@@ -16,6 +20,17 @@ func cloneClipboard(clip clipboard) clipboard {
 		cloned.cells[i] = append([]string(nil), row...)
 	}
 	return cloned
+}
+
+func (clip clipboard) String() string {
+	var build strings.Builder
+	for i, row := range clip.cells {
+		build.WriteString(strings.Join(row, "\t"))
+		if i < len(clip.cells)-1 {
+			build.WriteString("\n")
+		}
+	}
+	return build.String()
 }
 
 func (m *model) saveLastChange(keys []tea.KeyMsg) {
@@ -77,6 +92,7 @@ func (m *model) storeYankClipboard(clip clipboard) {
 		m.setRegisterClipboard(m.activeRegister, clip)
 	}
 	m.setUnnamedClipboard(clip)
+	_ = sysclip.WriteAll(clip.String())
 }
 
 func (m *model) storeDeleteClipboard(clip clipboard) {
@@ -88,6 +104,7 @@ func (m *model) storeDeleteClipboard(clip clipboard) {
 	}
 	m.shiftDeleteRegisters(clip)
 	m.setUnnamedClipboard(clip)
+	_ = sysclip.WriteAll(clip.String())
 }
 
 func (m model) clipboardForPaste() (clipboard, bool) {


### PR DESCRIPTION
This pull request resolves #7, integrating the system clipboard, allowing yanked (copied) and deleted cell content to be available outside the application. The main changes include importing the `github.com/atotto/clipboard` package, serializing clipboard data to a tab-separated string, and writing it to the system clipboard during yank and delete operations.

**System Clipboard Integration:**

- Added `github.com/atotto/clipboard` as a dependency in `go.mod` to enable cross-platform clipboard access.
- Imported the clipboard package as `sysclip` in `internal/sheets/clipboard.go`.
- Implemented the `String()` method for the `clipboard` type to serialize clipboard contents as tab-separated values, with rows separated by newlines.
- Updated `storeYankClipboard` and `storeDeleteClipboard` methods to write the serialized clipboard data to the system clipboard after yanking or deleting cells.