### PR TITLE
Make Ctrl-C act as Escape instead of quitting

### DIFF
--- a/internal/sheets/model.go
+++ b/internal/sheets/model.go
@@ -310,8 +310,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		if isQuitKey(msg) {
-			return m, tea.Quit
+		// Ctrl-C acts as Escape (like vim), not quit
+		if isCtrlCKey(msg) {
+			switch m.mode {
+			case insertMode:
+				if m.recordingInsert && !m.replayingChange {
+					m.insertKeys = append(m.insertKeys, msg)
+				}
+				return m.exitInsertMode()
+			case selectMode:
+				m.clearNormalPrefixes()
+				return m.exitSelectMode(), nil
+			case commandMode:
+				m.clearCommandPrompt()
+				return m, nil
+			}
+			// In normal mode, Ctrl-C does nothing (use q or :q to quit)
+			return m, nil
 		}
 		if !m.commandPending {
 			m.commandMessage = ""
@@ -385,7 +400,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func isQuitKey(msg tea.KeyMsg) bool {
+func isCtrlCKey(msg tea.KeyMsg) bool {
 	if msg.Type == tea.KeyCtrlC {
 		return true
 	}


### PR DESCRIPTION
## Summary

- Ctrl-C now behaves like Escape in all modes (matching vim behavior) instead of immediately quitting
- In INSERT mode, Ctrl-C exits to NORMAL mode (commits current edit)
- In SELECT/COMMAND mode, Ctrl-C exits to NORMAL mode
- In NORMAL mode, Ctrl-C is a no-op — use `q` or `:q` to quit

## Motivation

In vim, Ctrl-C never quits — it cancels the current operation and returns to normal mode. The current behavior of quitting on any Ctrl-C press is surprising for users with vim muscle memory and can cause loss of unsaved work.

## Test plan

- [x] Verify Ctrl-C in INSERT mode exits to NORMAL (like pressing Escape)
- [x] Verify Ctrl-C in SELECT mode exits to NORMAL
- [x] Verify Ctrl-C in COMMAND mode cancels the prompt
- [x] Verify Ctrl-C in NORMAL mode does nothing
- [x] Verify `q` and `:q` still quit as expected