### PR TITLE
feat: configurable keybindings via Helix-style TOML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Each section maps a key to an action name. Only specify the bindings you want to
 | `copy_selection` | Copy selection |
 | `copy_selection_ref` | Copy selection as reference |
 | `cut_selection` | Cut selection |
+| `delete_selection` | Clear selection without affecting clipboard |
 | `formula_from_selection` | Insert formula from selection |
 | `toggle_row_select` | Toggle row selection |
 | `toggle_selection_bold` | Toggle bold on selection |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,120 @@ Press <kbd>:</kbd> to open the command prompt, then use commands such as:
 - <kbd>:q</kbd> or <kbd>:wq</kbd> to quit
 - <kbd>:goto B9</kbd> or <kbd>:B9</kbd> to jump to a cell
 
+## Configuration
+
+Keybindings can be customized via a [Helix](https://docs.helix-editor.com/keymap.html)-style TOML config file at `~/.config/sheets/config.toml` (or `$XDG_CONFIG_HOME/sheets/config.toml`).
+
+```toml
+[keys.normal]
+"C-c" = "quit"
+"C-s" = "command_prompt"
+
+[keys.insert]
+"C-c" = "commit_down"
+
+[keys.select]
+"d" = "cut_selection"
+```
+
+Each section maps a key to an action name. Only specify the bindings you want to override — unset keys keep their defaults. Set a key to `"nop"` to disable it.
+
+<details>
+<summary>Available actions</summary>
+
+#### Navigation
+
+| Action | Description |
+|--------|-------------|
+| `move_left` | Move one cell left |
+| `move_right` | Move one cell right |
+| `move_up` | Move one cell up |
+| `move_down` | Move one cell down |
+| `move_to_first_col` | Jump to first column |
+| `move_to_first_nonempty_col` | Jump to first non-empty column |
+| `move_to_last_nonempty_col` | Jump to last non-empty column |
+| `move_to_window_top` | Jump to top visible row |
+| `move_to_window_middle` | Jump to middle visible row |
+| `move_to_window_bottom` | Jump to bottom visible row |
+| `scroll_half_up` | Scroll half page up |
+| `scroll_half_down` | Scroll half page down |
+| `goto_pending` | Start goto cell input |
+| `goto_bottom` | Jump to last row |
+| `jump_forward` | Jump list forward |
+| `jump_backward` | Jump list backward |
+
+#### Editing
+
+| Action | Description |
+|--------|-------------|
+| `enter_insert` | Edit current cell |
+| `enter_insert_start` | Edit from start of cell |
+| `change_cell` | Clear cell and edit |
+| `delete_pending` | Start delete row |
+| `open_col_after` | Insert column after and edit |
+| `open_col_before` | Insert column before and edit |
+| `open_row_below` | Insert row below and edit |
+| `open_row_above` | Insert row above and edit |
+| `yank` | Copy cell |
+| `cut` | Cut cell |
+| `paste` | Paste |
+| `undo` | Undo |
+| `redo` | Redo |
+| `repeat_change` | Repeat last change |
+| `toggle_bold` | Toggle bold formatting |
+
+#### Mode
+
+| Action | Description |
+|--------|-------------|
+| `quit` | Quit |
+| `command_prompt` | Open command prompt |
+| `search_forward` | Search forward |
+| `search_backward` | Search backward |
+| `search_next` | Next search match |
+| `search_prev` | Previous search match |
+| `enter_select` | Enter visual select |
+| `enter_row_select` | Enter row select |
+| `register_pending` | Select register |
+| `mark_set` | Set mark |
+| `mark_jump` | Jump to mark |
+| `mark_jump_exact` | Jump to mark (exact) |
+| `align_pending` | Start alignment command |
+
+#### Select mode
+
+| Action | Description |
+|--------|-------------|
+| `copy_selection` | Copy selection |
+| `copy_selection_ref` | Copy selection as reference |
+| `cut_selection` | Cut selection |
+| `formula_from_selection` | Insert formula from selection |
+| `toggle_row_select` | Toggle row selection |
+| `toggle_selection_bold` | Toggle bold on selection |
+
+#### Insert mode
+
+| Action | Description |
+|--------|-------------|
+| `commit_down` | Commit and move down |
+| `commit_right` | Commit and move right |
+| `commit_left` | Commit and move left |
+| `commit_up` | Commit and move up |
+| `cursor_left` | Move cursor left |
+| `cursor_right` | Move cursor right |
+| `cursor_home` | Move cursor to start |
+| `cursor_end` | Move cursor to end |
+| `delete_at_cursor` | Delete at cursor |
+| `delete_before_cursor` | Delete before cursor |
+| `delete_to_start` | Delete to start |
+| `delete_to_end` | Delete to end |
+| `delete_word_before` | Delete word before cursor |
+| `insert_space` | Insert space |
+
+</details>
+
+**Key notation:** `C-x` for Ctrl+x, `S-tab` for Shift+Tab, `ret` for Enter, `space`, `backspace`, `del`, `esc`, `up`/`down`/`left`/`right`, `home`/`end`, `tab`. Literal characters like `h`, `j`, `:`, `/` are written as-is.
+
 ## Installation
 
 <!--

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/sheets/action.go
+++ b/internal/sheets/action.go
@@ -56,6 +56,7 @@ const (
 	ActionCopySelection         Action = "copy_selection"
 	ActionCopySelectionRef      Action = "copy_selection_ref"
 	ActionCutSelection          Action = "cut_selection"
+	ActionDeleteSelection       Action = "delete_selection"
 	ActionFormulaFromSelection  Action = "formula_from_selection"
 	ActionToggleRowSelect       Action = "toggle_row_select"
 	ActionToggleSelectionBold   Action = "toggle_selection_bold"

--- a/internal/sheets/action.go
+++ b/internal/sheets/action.go
@@ -1,0 +1,81 @@
+package sheets
+
+// Action represents a named operation that can be triggered by a keybinding.
+type Action string
+
+// Normal mode actions.
+const (
+	ActionQuit                Action = "quit"
+	ActionCommandPrompt       Action = "command_prompt"
+	ActionSearchForward       Action = "search_forward"
+	ActionSearchBackward      Action = "search_backward"
+	ActionRegisterPending     Action = "register_pending"
+	ActionGotoPending         Action = "goto_pending"
+	ActionGotoBottom          Action = "goto_bottom"
+	ActionMoveLeft            Action = "move_left"
+	ActionMoveRight           Action = "move_right"
+	ActionMoveUp              Action = "move_up"
+	ActionMoveDown            Action = "move_down"
+	ActionMoveToFirstCol      Action = "move_to_first_col"
+	ActionMoveToFirstNonempty Action = "move_to_first_nonempty_col"
+	ActionMoveToLastNonempty  Action = "move_to_last_nonempty_col"
+	ActionMoveToWindowTop     Action = "move_to_window_top"
+	ActionMoveToWindowMiddle  Action = "move_to_window_middle"
+	ActionMoveToWindowBottom  Action = "move_to_window_bottom"
+	ActionScrollHalfUp        Action = "scroll_half_up"
+	ActionScrollHalfDown      Action = "scroll_half_down"
+	ActionAlignPending        Action = "align_pending"
+	ActionEnterInsert         Action = "enter_insert"
+	ActionEnterInsertStart    Action = "enter_insert_start"
+	ActionChangeCell          Action = "change_cell"
+	ActionDeletePending       Action = "delete_pending"
+	ActionOpenColAfter        Action = "open_col_after"
+	ActionOpenColBefore       Action = "open_col_before"
+	ActionOpenRowBelow        Action = "open_row_below"
+	ActionOpenRowAbove        Action = "open_row_above"
+	ActionEnterSelect         Action = "enter_select"
+	ActionEnterRowSelect      Action = "enter_row_select"
+	ActionUndo                Action = "undo"
+	ActionRedo                Action = "redo"
+	ActionYank                Action = "yank"
+	ActionCut                 Action = "cut"
+	ActionPaste               Action = "paste"
+	ActionSearchNext          Action = "search_next"
+	ActionSearchPrev          Action = "search_prev"
+	ActionRepeatChange        Action = "repeat_change"
+	ActionMarkSet             Action = "mark_set"
+	ActionMarkJump            Action = "mark_jump"
+	ActionMarkJumpExact       Action = "mark_jump_exact"
+	ActionToggleBold          Action = "toggle_bold"
+	ActionJumpForward         Action = "jump_forward"
+	ActionJumpBackward        Action = "jump_backward"
+)
+
+// Select mode actions (in addition to shared navigation actions).
+const (
+	ActionCopySelection         Action = "copy_selection"
+	ActionCopySelectionRef      Action = "copy_selection_ref"
+	ActionCutSelection          Action = "cut_selection"
+	ActionFormulaFromSelection  Action = "formula_from_selection"
+	ActionToggleRowSelect       Action = "toggle_row_select"
+	ActionToggleSelectionBold   Action = "toggle_selection_bold"
+)
+
+// Insert mode actions.
+const (
+	ActionCommitDown        Action = "commit_down"
+	ActionCommitRight       Action = "commit_right"
+	ActionCommitLeft        Action = "commit_left"
+	ActionCommitUp          Action = "commit_up"
+	ActionCursorLeft        Action = "cursor_left"
+	ActionCursorRight       Action = "cursor_right"
+	ActionCursorHome        Action = "cursor_home"
+	ActionCursorEnd         Action = "cursor_end"
+	ActionDeleteAtCursor    Action = "delete_at_cursor"
+	ActionDeleteBeforeCursor Action = "delete_before_cursor"
+	ActionDeleteToStart     Action = "delete_to_start"
+	ActionDeleteToEnd       Action = "delete_to_end"
+	ActionDeleteWordBefore  Action = "delete_word_before"
+	ActionInsertSpace       Action = "insert_space"
+	ActionInsertRunes       Action = "insert_runes"
+)

--- a/internal/sheets/clipboard.go
+++ b/internal/sheets/clipboard.go
@@ -251,6 +251,16 @@ func (m *model) cutSelection() {
 	}
 }
 
+func (m *model) deleteSelection() {
+	top, bottom, left, right := m.selectionBounds()
+	m.pushUndoState()
+	for row := top; row <= bottom; row++ {
+		for col := left; col <= right; col++ {
+			m.setCellValue(row, col, "")
+		}
+	}
+}
+
 func (m *model) pasteIntoCurrentCell(count int) bool {
 	clip, ok := m.clipboardForPaste()
 	if !ok {

--- a/internal/sheets/config.go
+++ b/internal/sheets/config.go
@@ -1,0 +1,178 @@
+package sheets
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Keymap maps key strings (Helix notation) to actions.
+type Keymap map[string]Action
+
+// KeymapConfig holds per-mode keymaps.
+type KeymapConfig struct {
+	Normal Keymap
+	Insert Keymap
+	Select Keymap
+}
+
+// configFile is the TOML structure matching Helix-style [keys.*] tables.
+type configFile struct {
+	Keys struct {
+		Normal map[string]string `toml:"normal"`
+		Insert map[string]string `toml:"insert"`
+		Select map[string]string `toml:"select"`
+	} `toml:"keys"`
+}
+
+// LoadKeymapConfig loads defaults and merges user overrides from
+// $XDG_CONFIG_HOME/sheets/config.toml (falls back to ~/.config/sheets/config.toml).
+func LoadKeymapConfig() KeymapConfig {
+	km := KeymapConfig{
+		Normal: defaultNormalKeys(),
+		Insert: defaultInsertKeys(),
+		Select: defaultSelectKeys(),
+	}
+
+	path := configPath()
+	if path == "" {
+		return km
+	}
+
+	var cfg configFile
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return km
+		}
+		return km
+	}
+
+	if len(cfg.Keys.Normal) > 0 {
+		km.Normal = mergeKeymap(km.Normal, toKeymap(cfg.Keys.Normal))
+	}
+	if len(cfg.Keys.Insert) > 0 {
+		km.Insert = mergeKeymap(km.Insert, toKeymap(cfg.Keys.Insert))
+	}
+	if len(cfg.Keys.Select) > 0 {
+		km.Select = mergeKeymap(km.Select, toKeymap(cfg.Keys.Select))
+	}
+
+	return km
+}
+
+func configPath() string {
+	dir := os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".config")
+	}
+	path := filepath.Join(dir, "sheets", "config.toml")
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}
+
+func toKeymap(m map[string]string) Keymap {
+	km := make(Keymap, len(m))
+	for k, v := range m {
+		km[k] = Action(v)
+	}
+	return km
+}
+
+func mergeKeymap(base, overrides Keymap) Keymap {
+	merged := make(Keymap, len(base)+len(overrides))
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range overrides {
+		if v == "nop" {
+			delete(merged, k)
+		} else {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
+// keyToString converts a tea.KeyMsg to a Helix-style key string.
+// Note: some bubbletea key constants share values (e.g. KeyTab == KeyCtrlI,
+// KeyEnter == KeyCtrlJ, KeyBackspace == KeyCtrlH). We map to the canonical
+// name and handle aliases via duplicate entries in the default keymaps.
+func keyToString(msg tea.KeyMsg) string {
+	switch msg.Type {
+	case tea.KeyCtrlA:
+		return "C-a"
+	case tea.KeyCtrlB:
+		return "C-b"
+	case tea.KeyCtrlC:
+		return "C-c"
+	case tea.KeyCtrlD:
+		return "C-d"
+	case tea.KeyCtrlE:
+		return "C-e"
+	case tea.KeyCtrlF:
+		return "C-f"
+	case tea.KeyCtrlG:
+		return "C-g"
+	// tea.KeyCtrlH == tea.KeyBackspace — handled as "backspace"
+	case tea.KeyBackspace:
+		return "backspace"
+	// tea.KeyCtrlI == tea.KeyTab — handled as "tab"
+	case tea.KeyTab:
+		return "tab"
+	// tea.KeyCtrlJ == tea.KeyEnter — handled as "ret"
+	case tea.KeyEnter:
+		return "ret"
+	case tea.KeyCtrlK:
+		return "C-k"
+	case tea.KeyCtrlL:
+		return "C-l"
+	case tea.KeyCtrlN:
+		return "C-n"
+	case tea.KeyCtrlO:
+		return "C-o"
+	case tea.KeyCtrlP:
+		return "C-p"
+	case tea.KeyCtrlR:
+		return "C-r"
+	case tea.KeyCtrlU:
+		return "C-u"
+	case tea.KeyCtrlW:
+		return "C-w"
+	case tea.KeyShiftTab:
+		return "S-tab"
+	case tea.KeyDelete:
+		return "del"
+	case tea.KeyEscape:
+		return "esc"
+	case tea.KeySpace:
+		return "space"
+	case tea.KeyUp:
+		return "up"
+	case tea.KeyDown:
+		return "down"
+	case tea.KeyLeft:
+		return "left"
+	case tea.KeyRight:
+		return "right"
+	case tea.KeyHome:
+		return "home"
+	case tea.KeyEnd:
+		return "end"
+	case tea.KeyRunes:
+		if len(msg.Runes) == 1 {
+			return string(msg.Runes)
+		}
+		return fmt.Sprintf("%s", string(msg.Runes))
+	}
+	return msg.String()
+}

--- a/internal/sheets/edit_mode.go
+++ b/internal/sheets/edit_mode.go
@@ -9,58 +9,83 @@ import (
 	"unicode"
 )
 
+func defaultInsertKeys() Keymap {
+	return Keymap{
+		"ret":       ActionCommitDown,
+		"tab":       ActionCommitRight,
+		"S-tab":     ActionCommitLeft,
+		"C-n":       ActionCommitDown,
+		"C-p":       ActionCommitUp,
+		"left":      ActionCursorLeft,
+		"C-b":       ActionCursorLeft,
+		"right":     ActionCursorRight,
+		"C-f":       ActionCursorRight,
+		"home":      ActionCursorHome,
+		"C-a":       ActionCursorHome,
+		"end":       ActionCursorEnd,
+		"C-e":       ActionCursorEnd,
+		"del":       ActionDeleteAtCursor,
+		"C-d":       ActionDeleteAtCursor,
+		"backspace": ActionDeleteBeforeCursor, // Ctrl+H == Backspace in terminals
+		"C-u":       ActionDeleteToStart,
+		"C-k":       ActionDeleteToEnd,
+		"C-w":       ActionDeleteWordBefore,
+		"space":     ActionInsertSpace,
+	}
+}
+
 func (m model) updateInsert(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.recordingInsert && !m.replayingChange {
 		m.insertKeys = append(m.insertKeys, msg)
 	}
-	switch msg.Type {
-	case tea.KeyEnter:
-		return m.moveInsertSelection(1, 0)
-	case tea.KeyTab:
-		return m.moveInsertSelection(0, 1)
-	case tea.KeyShiftTab:
-		return m.moveInsertSelection(0, -1)
-	case tea.KeyCtrlN:
-		return m.moveInsertSelection(1, 0)
-	case tea.KeyCtrlP:
-		return m.moveInsertSelection(-1, 0)
-	case tea.KeyLeft, tea.KeyCtrlB:
-		m.moveEditingCursor(-1)
-		return m, m.restartCursorBlink()
-	case tea.KeyRight, tea.KeyCtrlF:
-		m.moveEditingCursor(1)
-		return m, m.restartCursorBlink()
-	case tea.KeyHome, tea.KeyCtrlA:
-		m.editingCursor = 0
-		return m, m.restartCursorBlink()
-	case tea.KeyEnd, tea.KeyCtrlE:
-		m.editingCursor = len([]rune(strings.ReplaceAll(m.editingValue, "\n", " ")))
-		return m, m.restartCursorBlink()
-	case tea.KeyDelete, tea.KeyCtrlD:
-		m.deleteAtEditingCursor()
-		return m, m.restartCursorBlink()
-	case tea.KeySpace:
-		m.insertRunesAtEditingCursor([]rune{' '})
-		return m, m.restartCursorBlink()
-	case tea.KeyCtrlK:
-		m.deleteToEndOfEditingCursor()
-		return m, m.restartCursorBlink()
-	case tea.KeyCtrlU:
-		m.deleteToStartOfEditingCursor()
-		return m, m.restartCursorBlink()
-	case tea.KeyCtrlW:
-		m.deleteWordBeforeEditingCursor()
-		return m, m.restartCursorBlink()
-	case tea.KeyRunes:
-		if len(msg.Runes) > 0 {
-			m.insertRunesAtEditingCursor(msg.Runes)
+
+	action, ok := m.keymap.Insert[keyToString(msg)]
+	if ok {
+		switch action {
+		case ActionCommitDown:
+			return m.moveInsertSelection(1, 0)
+		case ActionCommitRight:
+			return m.moveInsertSelection(0, 1)
+		case ActionCommitLeft:
+			return m.moveInsertSelection(0, -1)
+		case ActionCommitUp:
+			return m.moveInsertSelection(-1, 0)
+		case ActionCursorLeft:
+			m.moveEditingCursor(-1)
+			return m, m.restartCursorBlink()
+		case ActionCursorRight:
+			m.moveEditingCursor(1)
+			return m, m.restartCursorBlink()
+		case ActionCursorHome:
+			m.editingCursor = 0
+			return m, m.restartCursorBlink()
+		case ActionCursorEnd:
+			m.editingCursor = len([]rune(strings.ReplaceAll(m.editingValue, "\n", " ")))
+			return m, m.restartCursorBlink()
+		case ActionDeleteAtCursor:
+			m.deleteAtEditingCursor()
+			return m, m.restartCursorBlink()
+		case ActionDeleteBeforeCursor:
+			m.deleteBeforeEditingCursor()
+			return m, m.restartCursorBlink()
+		case ActionDeleteToStart:
+			m.deleteToStartOfEditingCursor()
+			return m, m.restartCursorBlink()
+		case ActionDeleteToEnd:
+			m.deleteToEndOfEditingCursor()
+			return m, m.restartCursorBlink()
+		case ActionDeleteWordBefore:
+			m.deleteWordBeforeEditingCursor()
+			return m, m.restartCursorBlink()
+		case ActionInsertSpace:
+			m.insertRunesAtEditingCursor([]rune{' '})
 			return m, m.restartCursorBlink()
 		}
 	}
 
-	switch msg.String() {
-	case "backspace", "ctrl+h":
-		m.deleteBeforeEditingCursor()
+	// Fallback: insert typed runes (not configurable — raw text input).
+	if msg.Type == tea.KeyRunes && len(msg.Runes) > 0 {
+		m.insertRunesAtEditingCursor(msg.Runes)
 		return m, m.restartCursorBlink()
 	}
 

--- a/internal/sheets/model.go
+++ b/internal/sheets/model.go
@@ -35,6 +35,7 @@ func newModel() model {
 
 	return model{
 		mode:          normalMode,
+		keymap:        LoadKeymapConfig(),
 		rowCount:      defaultRows,
 		selectedRow:   0,
 		selectedCol:   0,

--- a/internal/sheets/normal_mode.go
+++ b/internal/sheets/normal_mode.go
@@ -8,187 +8,222 @@ import (
 	"unicode"
 )
 
+func defaultNormalKeys() Keymap {
+	return Keymap{
+		"h": ActionMoveLeft, "left": ActionMoveLeft,
+		"j": ActionMoveDown, "down": ActionMoveDown,
+		"k": ActionMoveUp, "up": ActionMoveUp,
+		"l": ActionMoveRight, "right": ActionMoveRight,
+		"0": ActionMoveToFirstCol,
+		"^": ActionMoveToFirstNonempty,
+		"$": ActionMoveToLastNonempty,
+		"H": ActionMoveToWindowTop,
+		"M": ActionMoveToWindowMiddle,
+		"L": ActionMoveToWindowBottom,
+		"C-d": ActionScrollHalfDown,
+		"C-u": ActionScrollHalfUp,
+		"g":   ActionGotoPending,
+		"G":   ActionGotoBottom,
+		"C-o": ActionJumpBackward,
+		"tab":  ActionJumpForward, // Ctrl+I == Tab in terminals
+		"q":  ActionQuit,
+		":":  ActionCommandPrompt,
+		"/":  ActionSearchForward,
+		"?":  ActionSearchBackward,
+		"i":  ActionEnterInsert,
+		"I":  ActionEnterInsertStart,
+		"c":  ActionChangeCell,
+		"d":  ActionDeletePending,
+		"a":  ActionOpenColAfter,
+		"A":  ActionOpenColBefore,
+		"o":  ActionOpenRowBelow,
+		"O":  ActionOpenRowAbove,
+		"v":  ActionEnterSelect,
+		"V":  ActionEnterRowSelect,
+		"u":  ActionUndo,
+		"U":  ActionRedo,
+		"C-r": ActionRedo,
+		"y":  ActionYank,
+		"x":  ActionCut,
+		"p":  ActionPaste,
+		".":  ActionRepeatChange,
+		"n":  ActionSearchNext,
+		"N":  ActionSearchPrev,
+		"m":  ActionMarkSet,
+		"'":  ActionMarkJump,
+		"`":  ActionMarkJumpExact,
+		"\"": ActionRegisterPending,
+		"C-b": ActionToggleBold,
+		"z":  ActionAlignPending,
+	}
+}
+
 func (m model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && isCountDigit(msg.Runes[0], m.countBuffer != "") {
 		m.countBuffer += string(msg.Runes[0])
 		return m, nil
 	}
 
+	action, ok := m.keymap.Normal[keyToString(msg)]
+	if !ok {
+		return m, nil
+	}
+
 	hasCount := m.countBuffer != ""
 	count := m.currentCount()
-	switch msg.Type {
-	case tea.KeyLeft:
+
+	switch action {
+	case ActionMoveLeft:
 		m.moveSelection(0, -count)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyDown:
+	case ActionMoveDown:
 		m.moveSelection(count, 0)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyUp:
+	case ActionMoveUp:
 		m.moveSelection(-count, 0)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyRight:
+	case ActionMoveRight:
 		m.moveSelection(0, count)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyCtrlD:
+	case ActionMoveToFirstCol:
+		m.moveToColumn(0)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToFirstNonempty:
+		m.moveToColumn(m.firstNonBlankColumn(m.selectedRow))
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToLastNonempty:
+		m.moveToColumn(m.lastNonBlankColumn(m.selectedRow))
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToWindowTop:
+		m.moveToWindowTop(count)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToWindowMiddle:
+		m.moveToWindowMiddle()
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToWindowBottom:
+		m.moveToWindowBottom(count)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionScrollHalfDown:
 		m.moveHalfPage(count)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyCtrlI:
-		m.navigateJumpList(1, count)
-		m.clearCount()
-		m.clearRegisterState()
-	case tea.KeyCtrlO:
-		m.navigateJumpList(-1, count)
-		m.clearCount()
-		m.clearRegisterState()
-	case tea.KeyCtrlR:
-		m.redoLastOperation()
-	case tea.KeyCtrlB:
-		m.toggleCellFormatting('*')
-		m.clearCount()
-		m.clearRegisterState()
-	case tea.KeyCtrlU:
+	case ActionScrollHalfUp:
 		m.moveHalfPage(-count)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyRunes:
-		switch string(msg.Runes) {
-		case "q":
-			return m, tea.Quit
-		case ":":
-			m.clearNormalPrefixes()
-			return m, m.startCommandPrompt()
-		case "/":
-			m.clearNormalPrefixes()
-			return m, m.startSearchPrompt(1)
-		case "?":
-			m.clearNormalPrefixes()
-			return m, m.startSearchPrompt(-1)
-		case "\"":
-			m.registerPending = true
-			return m, nil
-		case "g":
-			m.startGotoCellCommand()
-		case "G":
-			if hasCount {
-				m.recordJumpFromCurrent()
-				m.goToCell(count-1, m.selectedCol)
-			} else {
-				m.recordJumpFromCurrent()
-				m.goToBottom()
-			}
-			m.clearCount()
-			m.clearRegisterState()
-		case "h":
-			m.moveSelection(0, -count)
-			m.clearCount()
-			m.clearRegisterState()
-		case "j":
-			m.moveSelection(count, 0)
-			m.clearCount()
-			m.clearRegisterState()
-		case "k":
-			m.moveSelection(-count, 0)
-			m.clearCount()
-			m.clearRegisterState()
-		case "l":
-			m.moveSelection(0, count)
-			m.clearCount()
-			m.clearRegisterState()
-		case "0":
-			m.moveToColumn(0)
-			m.clearCount()
-			m.clearRegisterState()
-		case "^":
-			m.moveToColumn(m.firstNonBlankColumn(m.selectedRow))
-			m.clearCount()
-			m.clearRegisterState()
-		case "$":
-			m.moveToColumn(m.lastNonBlankColumn(m.selectedRow))
-			m.clearCount()
-			m.clearRegisterState()
-		case "H":
-			m.moveToWindowTop(count)
-			m.clearCount()
-			m.clearRegisterState()
-		case "M":
-			m.moveToWindowMiddle()
-			m.clearCount()
-			m.clearRegisterState()
-		case "L":
-			m.moveToWindowBottom(count)
-			m.clearCount()
-			m.clearRegisterState()
-		case "z":
-			m.zPending = true
-		case "i":
-			return m, m.enterInsertModeWithKeys(append(m.commandPrefixKeys(), msg))
-		case "I":
-			return m, m.enterInsertModeAtStartWithKeys(append(m.commandPrefixKeys(), msg))
-		case "c":
-			return m.changeCurrentCell(append(m.commandPrefixKeys(), msg))
-		case "d":
-			m.startDeleteRowCommand()
-		case "a":
-			return m, m.openColAfterWithKeys(append(m.commandPrefixKeys(), msg))
-		case "A":
-			return m, m.openColBeforeWithKeys(append(m.commandPrefixKeys(), msg))
-		case "o":
-			return m, m.openRowBelowWithKeys(append(m.commandPrefixKeys(), msg))
-		case "O":
-			return m, m.openRowAboveWithKeys(append(m.commandPrefixKeys(), msg))
-		case "v":
-			m.clearNormalPrefixes()
-			m.enterSelectMode()
-		case "V":
-			m.clearNormalPrefixes()
-			m.enterRowSelectMode()
-		case "u":
-			m.undoLastOperation()
-		case "U": // helix-like shift+u redo
-			m.redoLastOperation()
-		case "y":
-			m.copyCurrentCell(count)
-			m.yankCount = count
-			m.clearCount()
-			m.yankPending = true
-		case "x":
-			if m.cutCurrentCell(count) {
-				m.saveLastChange(append(m.commandPrefixKeys(), msg))
-			}
-			m.clearCount()
-			m.clearRegisterState()
-		case "p":
-			if m.pasteIntoCurrentCell(count) {
-				m.saveLastChange(append(m.commandPrefixKeys(), msg))
-			}
-			m.clearCount()
-			m.clearRegisterState()
-		case "n":
-			m.repeatSearch(count, false)
-			m.clearCount()
-			m.clearRegisterState()
-		case "N":
-			m.repeatSearch(count, true)
-			m.clearCount()
-			m.clearRegisterState()
-		case ".":
-			m.repeatLastChange(count)
-			m.clearCount()
-			m.clearRegisterState()
-		case "m":
-			m.markPending = true
-		case "'":
-			m.markJumpPending = true
-			m.markJumpExact = false
-		case "`":
-			m.markJumpPending = true
-			m.markJumpExact = true
+	case ActionGotoPending:
+		m.startGotoCellCommand()
+	case ActionGotoBottom:
+		if hasCount {
+			m.recordJumpFromCurrent()
+			m.goToCell(count-1, m.selectedCol)
+		} else {
+			m.recordJumpFromCurrent()
+			m.goToBottom()
 		}
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionJumpBackward:
+		m.navigateJumpList(-1, count)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionJumpForward:
+		m.navigateJumpList(1, count)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionQuit:
+		return m, tea.Quit
+	case ActionCommandPrompt:
+		m.clearNormalPrefixes()
+		return m, m.startCommandPrompt()
+	case ActionSearchForward:
+		m.clearNormalPrefixes()
+		return m, m.startSearchPrompt(1)
+	case ActionSearchBackward:
+		m.clearNormalPrefixes()
+		return m, m.startSearchPrompt(-1)
+	case ActionEnterInsert:
+		return m, m.enterInsertModeWithKeys(append(m.commandPrefixKeys(), msg))
+	case ActionEnterInsertStart:
+		return m, m.enterInsertModeAtStartWithKeys(append(m.commandPrefixKeys(), msg))
+	case ActionChangeCell:
+		return m.changeCurrentCell(append(m.commandPrefixKeys(), msg))
+	case ActionDeletePending:
+		m.startDeleteRowCommand()
+	case ActionOpenColAfter:
+		return m, m.openColAfterWithKeys(append(m.commandPrefixKeys(), msg))
+	case ActionOpenColBefore:
+		return m, m.openColBeforeWithKeys(append(m.commandPrefixKeys(), msg))
+	case ActionOpenRowBelow:
+		return m, m.openRowBelowWithKeys(append(m.commandPrefixKeys(), msg))
+	case ActionOpenRowAbove:
+		return m, m.openRowAboveWithKeys(append(m.commandPrefixKeys(), msg))
+	case ActionEnterSelect:
+		m.clearNormalPrefixes()
+		m.enterSelectMode()
+	case ActionEnterRowSelect:
+		m.clearNormalPrefixes()
+		m.enterRowSelectMode()
+	case ActionUndo:
+		m.undoLastOperation()
+	case ActionRedo:
+		m.redoLastOperation()
+	case ActionYank:
+		m.copyCurrentCell(count)
+		m.yankCount = count
+		m.clearCount()
+		m.yankPending = true
+	case ActionCut:
+		if m.cutCurrentCell(count) {
+			m.saveLastChange(append(m.commandPrefixKeys(), msg))
+		}
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionPaste:
+		if m.pasteIntoCurrentCell(count) {
+			m.saveLastChange(append(m.commandPrefixKeys(), msg))
+		}
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionRepeatChange:
+		m.repeatLastChange(count)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionSearchNext:
+		m.repeatSearch(count, false)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionSearchPrev:
+		m.repeatSearch(count, true)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMarkSet:
+		m.markPending = true
+	case ActionMarkJump:
+		m.markJumpPending = true
+		m.markJumpExact = false
+	case ActionMarkJumpExact:
+		m.markJumpPending = true
+		m.markJumpExact = true
+	case ActionRegisterPending:
+		m.registerPending = true
+		return m, nil
+	case ActionToggleBold:
+		m.toggleCellFormatting('*')
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionAlignPending:
+		m.zPending = true
 	}
 
 	return m, nil

--- a/internal/sheets/select_mode.go
+++ b/internal/sheets/select_mode.go
@@ -2,152 +2,178 @@ package sheets
 
 import tea "github.com/charmbracelet/bubbletea"
 
+func defaultSelectKeys() Keymap {
+	return Keymap{
+		"h": ActionMoveLeft, "left": ActionMoveLeft,
+		"j": ActionMoveDown, "down": ActionMoveDown,
+		"k": ActionMoveUp, "up": ActionMoveUp,
+		"l": ActionMoveRight, "right": ActionMoveRight,
+		"0":    ActionMoveToFirstCol,
+		"^":    ActionMoveToFirstNonempty,
+		"$":    ActionMoveToLastNonempty,
+		"H":    ActionMoveToWindowTop,
+		"M":    ActionMoveToWindowMiddle,
+		"L":    ActionMoveToWindowBottom,
+		"C-d":  ActionScrollHalfDown,
+		"C-u":  ActionScrollHalfUp,
+		"g":    ActionGotoPending,
+		"G":    ActionGotoBottom,
+		"C-o":  ActionJumpBackward,
+		"tab":   ActionJumpForward, // Ctrl+I == Tab in terminals
+		"y":    ActionCopySelection,
+		"Y":    ActionCopySelectionRef,
+		"x":    ActionCutSelection,
+		"=":    ActionFormulaFromSelection,
+		"V":    ActionToggleRowSelect,
+		"u":    ActionUndo,
+		"U":    ActionRedo,
+		"C-r":  ActionRedo,
+		"/":    ActionSearchForward,
+		"?":    ActionSearchBackward,
+		"n":    ActionSearchNext,
+		"N":    ActionSearchPrev,
+		"m":    ActionMarkSet,
+		"'":    ActionMarkJump,
+		"`":    ActionMarkJumpExact,
+		"\"":   ActionRegisterPending,
+		"C-b":  ActionToggleSelectionBold,
+		"z":    ActionAlignPending,
+	}
+}
+
 func (m model) updateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && isCountDigit(msg.Runes[0], m.countBuffer != "") {
 		m.countBuffer += string(msg.Runes[0])
 		return m, nil
 	}
 
+	action, ok := m.keymap.Select[keyToString(msg)]
+	if !ok {
+		return m, nil
+	}
+
 	count := m.currentCount()
-	switch msg.Type {
-	case tea.KeyLeft:
+
+	switch action {
+	case ActionMoveLeft:
 		m.moveSelection(0, -count)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyDown:
+	case ActionMoveDown:
 		m.moveSelection(count, 0)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyUp:
+	case ActionMoveUp:
 		m.moveSelection(-count, 0)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyRight:
+	case ActionMoveRight:
 		m.moveSelection(0, count)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyCtrlD:
+	case ActionMoveToFirstCol:
+		m.moveToColumn(0)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToFirstNonempty:
+		m.moveToColumn(m.firstNonBlankColumn(m.selectedRow))
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToLastNonempty:
+		m.moveToColumn(m.lastNonBlankColumn(m.selectedRow))
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToWindowTop:
+		m.moveToWindowTop(count)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToWindowMiddle:
+		m.moveToWindowMiddle()
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMoveToWindowBottom:
+		m.moveToWindowBottom(count)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionScrollHalfDown:
 		m.moveHalfPage(count)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyCtrlI:
-		m.navigateJumpList(1, count)
-		m.clearCount()
-		m.clearRegisterState()
-	case tea.KeyCtrlO:
-		m.navigateJumpList(-1, count)
-		m.clearCount()
-		m.clearRegisterState()
-	case tea.KeyCtrlR:
-		m.redoLastOperation()
-	case tea.KeyCtrlB:
-		m.toggleSelectionFormatting('*')
-		m.clearCount()
-		m.clearRegisterState()
-	case tea.KeyCtrlU:
+	case ActionScrollHalfUp:
 		m.moveHalfPage(-count)
 		m.clearCount()
 		m.clearRegisterState()
-	case tea.KeyRunes:
-		switch string(msg.Runes) {
-		case "g":
-			m.startGotoCellCommand()
-		case "G":
-			m.recordJumpFromCurrent()
-			m.goToBottom()
-			m.clearCount()
-			m.clearRegisterState()
-		case "h":
-			m.moveSelection(0, -count)
-			m.clearCount()
-			m.clearRegisterState()
-		case "j":
-			m.moveSelection(count, 0)
-			m.clearCount()
-			m.clearRegisterState()
-		case "k":
-			m.moveSelection(-count, 0)
-			m.clearCount()
-			m.clearRegisterState()
-		case "l":
-			m.moveSelection(0, count)
-			m.clearCount()
-			m.clearRegisterState()
-		case "0":
-			m.moveToColumn(0)
-			m.clearCount()
-			m.clearRegisterState()
-		case "^":
-			m.moveToColumn(m.firstNonBlankColumn(m.selectedRow))
-			m.clearCount()
-			m.clearRegisterState()
-		case "$":
-			m.moveToColumn(m.lastNonBlankColumn(m.selectedRow))
-			m.clearCount()
-			m.clearRegisterState()
-		case "H":
-			m.moveToWindowTop(count)
-			m.clearCount()
-			m.clearRegisterState()
-		case "M":
-			m.moveToWindowMiddle()
-			m.clearCount()
-			m.clearRegisterState()
-		case "L":
-			m.moveToWindowBottom(count)
-			m.clearCount()
-			m.clearRegisterState()
-		case "z":
-			m.zPending = true
-		case "V":
-			m.selectRows = true
-		case "U":
-			m.undoLastOperation()
-		case "y":
-			m.copySelection()
-			m.clearCount()
-			m.clearRegisterState()
-			return m.exitSelectMode(), nil
-		case "Y":
-			m.copySelectionReference()
-			m.clearCount()
-			m.clearRegisterState()
-			return m.exitSelectMode(), nil
-		case "=":
-			m.clearCount()
-			m.clearRegisterState()
-			return m.startFormulaFromSelection()
-		case "x":
-			m.cutSelection()
-			m.clearCount()
-			m.clearRegisterState()
-			return m.exitSelectMode(), nil
-		case "/":
-			m.clearNormalPrefixes()
-			return m, m.startSearchPrompt(1)
-		case "?":
-			m.clearNormalPrefixes()
-			return m, m.startSearchPrompt(-1)
-		case "n":
-			m.repeatSearch(count, false)
-			m.clearCount()
-			m.clearRegisterState()
-		case "N":
-			m.repeatSearch(count, true)
-			m.clearCount()
-			m.clearRegisterState()
-		case "m":
-			m.markPending = true
-		case "'":
-			m.markJumpPending = true
-			m.markJumpExact = false
-		case "`":
-			m.markJumpPending = true
-			m.markJumpExact = true
-		case "\"":
-			m.registerPending = true
-			return m, nil
-		}
+	case ActionGotoPending:
+		m.startGotoCellCommand()
+	case ActionGotoBottom:
+		m.recordJumpFromCurrent()
+		m.goToBottom()
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionJumpBackward:
+		m.navigateJumpList(-1, count)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionJumpForward:
+		m.navigateJumpList(1, count)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionCopySelection:
+		m.copySelection()
+		m.clearCount()
+		m.clearRegisterState()
+		return m.exitSelectMode(), nil
+	case ActionCopySelectionRef:
+		m.copySelectionReference()
+		m.clearCount()
+		m.clearRegisterState()
+		return m.exitSelectMode(), nil
+	case ActionCutSelection:
+		m.cutSelection()
+		m.clearCount()
+		m.clearRegisterState()
+		return m.exitSelectMode(), nil
+	case ActionFormulaFromSelection:
+		m.clearCount()
+		m.clearRegisterState()
+		return m.startFormulaFromSelection()
+	case ActionToggleRowSelect:
+		m.selectRows = true
+	case ActionUndo:
+		m.undoLastOperation()
+	case ActionRedo:
+		m.redoLastOperation()
+	case ActionSearchForward:
+		m.clearNormalPrefixes()
+		return m, m.startSearchPrompt(1)
+	case ActionSearchBackward:
+		m.clearNormalPrefixes()
+		return m, m.startSearchPrompt(-1)
+	case ActionSearchNext:
+		m.repeatSearch(count, false)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionSearchPrev:
+		m.repeatSearch(count, true)
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionMarkSet:
+		m.markPending = true
+	case ActionMarkJump:
+		m.markJumpPending = true
+		m.markJumpExact = false
+	case ActionMarkJumpExact:
+		m.markJumpPending = true
+		m.markJumpExact = true
+	case ActionRegisterPending:
+		m.registerPending = true
+		return m, nil
+	case ActionToggleSelectionBold:
+		m.toggleSelectionFormatting('*')
+		m.clearCount()
+		m.clearRegisterState()
+	case ActionAlignPending:
+		m.zPending = true
 	}
 
 	return m, nil

--- a/internal/sheets/select_mode.go
+++ b/internal/sheets/select_mode.go
@@ -23,6 +23,7 @@ func defaultSelectKeys() Keymap {
 		"y":    ActionCopySelection,
 		"Y":    ActionCopySelectionRef,
 		"x":    ActionCutSelection,
+		"D":    ActionDeleteSelection,
 		"=":    ActionFormulaFromSelection,
 		"V":    ActionToggleRowSelect,
 		"u":    ActionUndo,
@@ -130,6 +131,11 @@ func (m model) updateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.exitSelectMode(), nil
 	case ActionCutSelection:
 		m.cutSelection()
+		m.clearCount()
+		m.clearRegisterState()
+		return m.exitSelectMode(), nil
+	case ActionDeleteSelection:
+		m.deleteSelection()
 		m.clearCount()
 		m.clearRegisterState()
 		return m.exitSelectMode(), nil

--- a/internal/sheets/types.go
+++ b/internal/sheets/types.go
@@ -141,6 +141,8 @@ type model struct {
 	rowOffset   int
 	colOffset   int
 
+	keymap KeymapConfig
+
 	cellWidth     int
 	rowLabelWidth int
 


### PR DESCRIPTION
## Summary

- Refactor hardcoded key switch statements into action-based dispatch with per-mode keymaps
- Add TOML config at `$XDG_CONFIG_HOME/sheets/config.toml` with `[keys.normal]`, `[keys.insert]`, and `[keys.select]` tables (Helix-style)
- Users override only the bindings they want — unset keys keep defaults, `"nop"` disables a key
- All existing behavior preserved, zero regressions

## Motivation

As a Helix user myself, I wanted the config format @maaslalani described in #6:

> I would love to emulate Helix here

And the TOML approach @verysleepylemon proposed in #23, using `[keys.normal]` / `[keys.insert]` tables with XDG-friendly paths — rather than the vim-style `.sheetsrc` format.

This also addresses #24 by making it trivial to add non-conflicting bindings (e.g. `"d" = "cut_selection"` in select mode).

## Architecture

Two new files, five modified:

- **`action.go`** — `Action` type + named constants for every bindable operation
- **`config.go`** — `Keymap` type, `keyToString()`, TOML loading via `github.com/BurntSushi/toml`, `mergeKeymap()`
- **`normal_mode.go`** / **`select_mode.go`** / **`edit_mode.go`** — default keymap at top of file, switch on `Action` instead of key strings (logic stays co-located)
- **`types.go`** — `keymap KeymapConfig` field on model
- **`model.go`** — `LoadKeymapConfig()` in `newModel()`

Pending modes (`handlePendingGoto`, `handlePendingDelete`, etc.) stay hardcoded — these are mini-parsers for cell references and multi-key sequences, not bindable actions.

## Example config

```toml
# ~/.config/sheets/config.toml

[keys.normal]
"C-s" = "command_prompt"

[keys.select]
"d" = "cut_selection"
```

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./...` passes (rebased on latest main including #30)
- [x] Manual testing: navigation, insert, visual select, undo/redo, search, marks, formulas all work identically
- [x] Config override tested: added `d = cut_selection` in select mode, verified it works alongside existing `x`
- [x] Missing config file: defaults load, no error

Closes #6, closes #23, relates to #24