### PR TITLE
feat: add per-column resize, auto-fit, and cell peek overlay

### DIFF
--- a/internal/sheets/commands.go
+++ b/internal/sheets/commands.go
@@ -131,7 +131,7 @@ func (m *model) executePrompt() tea.Cmd {
 		return tea.Quit
 	case strings.EqualFold(command, "help"),
 		strings.EqualFold(command, "?"):
-		m.commandMessage = "Commands: q, w, wq, x, goto <cell>, <cell>, e[dit] <path>, w[rite] [path]"
+		m.commandMessage = "Commands: q, w, wq, x, goto <cell>, <cell>, e[dit] <path>, w[rite] [path], fitall | Enter=peek, +/-=resize col, ==autofit col"
 		m.commandError = false
 		return nil
 	}
@@ -191,6 +191,27 @@ func (m *model) executePrompt() tea.Cmd {
 			return nil
 		}
 		m.commandMessage = fmt.Sprintf("loaded %s", arg)
+		m.commandError = false
+		return nil
+	}
+
+	if strings.EqualFold(command, "fitall") || strings.EqualFold(command, "fa") {
+		maxAllowed := m.width - m.rowLabelWidth - 4
+		for key := range m.cells {
+			col := key.col
+			if _, done := m.colWidths[col]; done {
+				continue
+			}
+			w := m.maxContentWidthForCol(col) + 2
+			if w < 4 {
+				w = 4
+			}
+			if w > maxAllowed {
+				w = maxAllowed
+			}
+			m.colWidths[col] = w
+		}
+		m.commandMessage = "auto-fitted all columns"
 		m.commandError = false
 		return nil
 	}

--- a/internal/sheets/edit_mode.go
+++ b/internal/sheets/edit_mode.go
@@ -172,7 +172,7 @@ func (m model) exitInsertMode() (tea.Model, tea.Cmd) {
 func (m model) renderEditingCell() string {
 	cursorModel := m.editCursor
 	cursorModel.TextStyle = lipgloss.NewStyle()
-	return renderTextInput(m.editingValue, m.editingCursor, m.cellWidth, cursorModel, lipgloss.NewStyle())
+	return renderTextInput(m.editingValue, m.editingCursor, m.colWidth(m.selectedCol), cursorModel, lipgloss.NewStyle())
 }
 
 func (m *model) moveEditingCursor(delta int) {

--- a/internal/sheets/main_test.go
+++ b/internal/sheets/main_test.go
@@ -3024,3 +3024,162 @@ func TestCellFromMouseMapping(t *testing.T) {
 		t.Fatal("expected click on column border to return false")
 	}
 }
+
+func TestPeekEnterOpensAndAnyKeyCloses(t *testing.T) {
+	m := newModel()
+	m.width = 80
+	m.height = 24
+	m.setCellValue(0, 0, "hello world this is a long value")
+
+	// Enter opens peek
+	m = applyKey(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.peekActive {
+		t.Fatal("expected peekActive after Enter")
+	}
+
+	// View should contain the cell ref and value
+	view := m.View()
+	assertContainsAll(t, "peek view", view, "A1", "hello world this is a long value")
+
+	// Any key closes peek
+	m = applyKey(t, m, runeKey("x"))
+	if m.peekActive {
+		t.Fatal("expected peekActive to be false after dismiss")
+	}
+}
+
+func TestPeekEmptyCellShowsEmpty(t *testing.T) {
+	m := newModel()
+	m.width = 80
+	m.height = 24
+
+	m = applyKey(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	view := m.View()
+	assertContainsAll(t, "peek view", view, "(empty)")
+}
+
+func TestPeekEscapeCloses(t *testing.T) {
+	m := newModel()
+	m.width = 80
+	m.height = 24
+	m.setCellValue(0, 0, "test")
+
+	m = applyKey(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.peekActive {
+		t.Fatal("expected peekActive")
+	}
+	m = applyKey(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.peekActive {
+		t.Fatal("expected peekActive false after Escape")
+	}
+}
+
+func TestResizeColumnPlus(t *testing.T) {
+	m := newModel()
+	m.width = 80
+	m.height = 24
+	original := m.colWidth(0)
+
+	m = applyKey(t, m, runeKey("+"))
+	if m.colWidth(0) != original+2 {
+		t.Fatalf("expected col 0 width %d, got %d", original+2, m.colWidth(0))
+	}
+	// Other columns should be unchanged
+	if m.colWidth(1) != original {
+		t.Fatalf("expected col 1 width %d (unchanged), got %d", original, m.colWidth(1))
+	}
+}
+
+func TestResizeColumnMinus(t *testing.T) {
+	m := newModel()
+	m.width = 80
+	m.height = 24
+	original := m.colWidth(0)
+
+	m = applyKey(t, m, runeKey("-"))
+	if m.colWidth(0) != original-2 {
+		t.Fatalf("expected col 0 width %d, got %d", original-2, m.colWidth(0))
+	}
+}
+
+func TestResizeColumnMinimum(t *testing.T) {
+	m := newModel()
+	m.width = 80
+	m.height = 24
+	m.colWidths[0] = 4
+
+	m = applyKey(t, m, runeKey("-"))
+	if m.colWidth(0) != 4 {
+		t.Fatalf("expected col width to stay at 4, got %d", m.colWidth(0))
+	}
+}
+
+func TestAutoFitCurrentColumn(t *testing.T) {
+	m := newModel()
+	m.width = 120
+	m.height = 24
+	m.setCellValue(0, 0, "short")
+	m.setCellValue(1, 0, "a longer value here")
+	m.setCellValue(0, 1, "other column with wide content")
+
+	m = applyKey(t, m, runeKey("="))
+	// Col 0 should fit "a longer value here" (19 chars) + 2 padding = 21
+	if m.colWidth(0) != 21 {
+		t.Fatalf("expected col 0 auto-fit to 21, got %d", m.colWidth(0))
+	}
+	// Col 1 should be unchanged (default)
+	if _, ok := m.colWidths[1]; ok {
+		t.Fatal("expected col 1 to remain at default width")
+	}
+}
+
+func TestFitAllCommand(t *testing.T) {
+	m := newModel()
+	m.width = 200
+	m.height = 24
+	m.setCellValue(0, 0, "hello")      // 5 + 2 = 7
+	m.setCellValue(0, 1, "world12345") // 10 + 2 = 12
+
+	m = applyKeys(t, m, runeKey(":"))
+	for _, r := range "fitall" {
+		m = applyKey(t, m, runeKey(string(r)))
+	}
+	m = applyKey(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.colWidth(0) != 7 {
+		t.Fatalf("expected col 0 width 7, got %d", m.colWidth(0))
+	}
+	if m.colWidth(1) != 12 {
+		t.Fatalf("expected col 1 width 12, got %d", m.colWidth(1))
+	}
+}
+
+func TestPerColumnWidthRendering(t *testing.T) {
+	m := newModel()
+	m.width = 80
+	m.height = 24
+	m.setCellValue(0, 0, "narrow")
+	m.setCellValue(0, 1, "wide content here")
+	m.colWidths[0] = 8
+	m.colWidths[1] = 20
+
+	view := m.View()
+	// Col 0 should truncate/fit to 8 chars, col 1 should show full content
+	assertContainsAll(t, "rendered view", view, "narrow", "wide content here")
+}
+
+func TestVisibleColsWithPerColumnWidths(t *testing.T) {
+	m := newModel()
+	m.width = 40
+	m.height = 24
+	m.colWidths[0] = 10
+	m.colWidths[1] = 10
+	m.colWidths[2] = 10
+
+	vis := m.visibleCols()
+	// Available = 40 - rowLabelWidth - 2; each col takes 11 (10+1 border)
+	// Should fit a limited number based on actual widths
+	if vis < 1 {
+		t.Fatalf("expected at least 1 visible col, got %d", vis)
+	}
+}

--- a/internal/sheets/model.go
+++ b/internal/sheets/model.go
@@ -41,6 +41,7 @@ func newModel() model {
 		selectRow:     0,
 		selectCol:     0,
 		cellWidth:     12,
+		colWidths:     make(map[int]int),
 		rowLabelWidth: rowLabelWidthForCount(defaultRows),
 		cells:         make(map[cellKey]string),
 		registers:     make(map[rune]clipboard),
@@ -182,6 +183,7 @@ func (m *model) loadCSV(records [][]string) error {
 	}
 
 	m.cells = make(map[cellKey]string)
+	m.colWidths = make(map[int]int)
 	m.rowCount = defaultRows
 	m.syncRowLabelWidth()
 	m.undoStack = nil
@@ -321,6 +323,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		if isQuitKey(msg) {
 			return m, tea.Quit
+		}
+		if m.peekActive {
+			m.peekActive = false
+			return m, nil
 		}
 		if !m.commandPending {
 			m.commandMessage = ""

--- a/internal/sheets/navigate.go
+++ b/internal/sheets/navigate.go
@@ -131,16 +131,26 @@ func (m model) halfPageRows() int {
 
 func (m model) visibleCols() int {
 	available := m.width - m.rowLabelWidth - 2
-	if available <= m.cellWidth+1 {
-		return 1
+	used := 0
+	cols := 0
+	for c := m.colOffset; c < totalCols; c++ {
+		w := m.colWidth(c) + 1 // +1 for border
+		if cols == 0 {
+			// always show at least one column
+			cols = 1
+			used = w
+			continue
+		}
+		if used+w > available {
+			break
+		}
+		used += w
+		cols++
 	}
-
-	cols := available / (m.cellWidth + 1)
 	if cols < 1 {
 		return 1
 	}
-
-	return min(cols, totalCols-m.colOffset)
+	return cols
 }
 
 func (m model) firstNonBlankColumn(row int) int {
@@ -217,12 +227,15 @@ func (m model) cellFromMouse(x, y int) (row, col int, ok bool) {
 		return 0, 0, false
 	}
 
-	stride := m.cellWidth + 1
-	visibleColIndex := (x - cellAreaStart) / stride
-	offsetInStride := (x - cellAreaStart) % stride
-	if offsetInStride >= m.cellWidth || visibleColIndex >= m.visibleCols() {
-		return 0, 0, false
+	pos := cellAreaStart
+	visCols := m.visibleCols()
+	for i := 0; i < visCols; i++ {
+		c := m.colOffset + i
+		w := m.colWidth(c)
+		if x >= pos && x < pos+w {
+			return m.rowOffset + visibleRowIndex, c, true
+		}
+		pos += w + 1 // +1 for border
 	}
-
-	return m.rowOffset + visibleRowIndex, m.colOffset + visibleColIndex, true
+	return 0, 0, false
 }

--- a/internal/sheets/normal_mode.go
+++ b/internal/sheets/normal_mode.go
@@ -47,6 +47,9 @@ func (m model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.clearRegisterState()
 	case tea.KeyCtrlR:
 		m.redoLastOperation()
+	case tea.KeyEnter:
+		m.peekActive = true
+		m.clearNormalPrefixes()
 	case tea.KeyCtrlB:
 		m.toggleCellFormatting('*')
 		m.clearCount()
@@ -193,6 +196,32 @@ func (m model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "`":
 			m.markJumpPending = true
 			m.markJumpExact = true
+		case "+":
+			col := m.selectedCol
+			m.colWidths[col] = m.colWidth(col) + 2
+			m.clearCount()
+			m.clearRegisterState()
+		case "-":
+			col := m.selectedCol
+			cur := m.colWidth(col)
+			if cur > 4 {
+				m.colWidths[col] = cur - 2
+			}
+			m.clearCount()
+			m.clearRegisterState()
+		case "=":
+			col := m.selectedCol
+			w := m.maxContentWidthForCol(col) + 2
+			if w < 4 {
+				w = 4
+			}
+			maxAllowed := m.width - m.rowLabelWidth - 4
+			if w > maxAllowed {
+				w = maxAllowed
+			}
+			m.colWidths[col] = w
+			m.clearCount()
+			m.clearRegisterState()
 		}
 	}
 

--- a/internal/sheets/render.go
+++ b/internal/sheets/render.go
@@ -2,6 +2,7 @@ package sheets
 
 import (
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 	"strconv"
 	"strings"
@@ -38,7 +39,13 @@ func (m model) View() string {
 		parts = append(parts, commandLine)
 	}
 	parts = append(parts, bottomBar)
-	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	view := lipgloss.JoinVertical(lipgloss.Left, parts...)
+
+	if m.peekActive {
+		return m.renderPeekOverlay(view)
+	}
+
+	return view
 }
 
 func (m model) renderStatusSpacer(contentHeight int) string {
@@ -143,9 +150,11 @@ func (m model) renderColumnHeaders() string {
 	var b strings.Builder
 	b.WriteString(strings.Repeat(" ", m.rowLabelWidth+2))
 
-	for i := 0; i < m.visibleCols(); i++ {
+	visCols := m.visibleCols()
+	for i := 0; i < visCols; i++ {
 		col := m.colOffset + i
-		label := alignCenter(columnLabel(col), m.cellWidth)
+		w := m.colWidth(col)
+		label := alignCenter(columnLabel(col), w)
 		if m.mode == selectMode && m.selectionContains(m.selectedRow, col) {
 			b.WriteString(m.activeHeaderStyle.Render(label))
 		} else if col == m.selectedCol {
@@ -154,7 +163,7 @@ func (m model) renderColumnHeaders() string {
 			b.WriteString(m.headerStyle.Render(label))
 		}
 
-		if i < m.visibleCols()-1 {
+		if i < visCols-1 {
 			b.WriteString(" ")
 		}
 	}
@@ -190,9 +199,9 @@ func (m model) renderBorderLine(borderRow int, left, middle, right string, visib
 	b.WriteString(" ")
 	b.WriteString(m.renderBorderJunction(borderRow, m.colOffset, left))
 
-	segment := strings.Repeat("─", m.cellWidth)
 	for i := range visibleCols {
 		col := m.colOffset + i
+		segment := strings.Repeat("─", m.colWidth(col))
 		b.WriteString(m.renderBorderSegment(borderRow, col, segment))
 		if i == visibleCols-1 {
 			b.WriteString(m.renderBorderJunction(borderRow, col+1, right))
@@ -221,7 +230,8 @@ func (m model) renderContentLine(row, visibleCols int) string {
 
 	for i := range visibleCols {
 		col := m.colOffset + i
-		cell := fit(m.displayValue(row, col), m.cellWidth)
+		w := m.colWidth(col)
+		cell := fit(m.displayValue(row, col), w)
 		formula := m.isFormulaDisplayCell(row, col)
 		formulaError := formula && m.isFormulaErrorDisplayCell(row, col)
 		raw := m.cellValue(row, col)
@@ -499,6 +509,95 @@ func fitLeft(value string, width int) string {
 	}
 
 	return strings.Repeat(" ", width-w) + value
+}
+
+func (m model) renderPeekOverlay(base string) string {
+	ref := cellRef(m.selectedRow, m.selectedCol)
+	value := m.activeValue()
+	if value == "" {
+		value = "(empty)"
+	}
+
+	// Box dimensions: up to 60% of screen, min 30 wide
+	boxInner := m.width*3/5 - 4
+	if boxInner < 26 {
+		boxInner = 26
+	}
+	if boxInner > m.width-6 {
+		boxInner = m.width - 6
+	}
+	maxLines := m.height*3/5 - 4
+	if maxLines < 3 {
+		maxLines = 3
+	}
+
+	// Wrap content into lines
+	var contentLines []string
+	for _, line := range strings.Split(value, "\n") {
+		runes := []rune(line)
+		for len(runes) > boxInner {
+			contentLines = append(contentLines, string(runes[:boxInner]))
+			runes = runes[boxInner:]
+		}
+		contentLines = append(contentLines, string(runes))
+	}
+	if len(contentLines) > maxLines {
+		contentLines = contentLines[:maxLines]
+		contentLines = append(contentLines, "…")
+	}
+
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("33"))
+	title := titleStyle.Render(ref) + dimStyle.Render("  press any key to close")
+
+	body := strings.Join(contentLines, "\n")
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("33")).
+		Padding(0, 1).
+		Width(boxInner)
+
+	box := boxStyle.Render(title + "\n" + body)
+	boxW := lipgloss.Width(box)
+	boxH := lipgloss.Height(box)
+
+	// Center position
+	startCol := (m.width - boxW) / 2
+	startRow := (m.height - boxH) / 2
+	if startCol < 0 {
+		startCol = 0
+	}
+	if startRow < 0 {
+		startRow = 0
+	}
+
+	// Overlay box onto base using ANSI-aware truncation
+	baseLines := strings.Split(base, "\n")
+	boxLines := strings.Split(box, "\n")
+
+	for i, bLine := range boxLines {
+		row := startRow + i
+		if row >= len(baseLines) {
+			break
+		}
+
+		bl := baseLines[row]
+
+		// Left part: ANSI-aware truncate to startCol
+		left := ansi.Truncate(bl, startCol, "")
+		leftW := lipgloss.Width(left)
+		if leftW < startCol {
+			left += strings.Repeat(" ", startCol-leftW)
+		}
+
+		// Right part: strip startCol+boxW chars from left side
+		right := ansi.TruncateLeft(bl, startCol+boxW, "")
+
+		baseLines[row] = left + bLine + right
+	}
+
+	return strings.Join(baseLines, "\n")
 }
 
 func truncate(value string, width int) string {

--- a/internal/sheets/types.go
+++ b/internal/sheets/types.go
@@ -133,6 +133,7 @@ type model struct {
 	markJumpExact   bool
 	commandError    bool
 	dirtyFile       bool
+	peekActive      bool
 
 	selectedRow int
 	selectedCol int
@@ -143,6 +144,7 @@ type model struct {
 	colOffset   int
 
 	cellWidth     int
+	colWidths     map[int]int
 	rowLabelWidth int
 
 	cells           map[cellKey]string

--- a/internal/sheets/util.go
+++ b/internal/sheets/util.go
@@ -1,6 +1,7 @@
 package sheets
 
 import (
+	"github.com/mattn/go-runewidth"
 	"strconv"
 	"strings"
 )
@@ -278,6 +279,28 @@ func columnLabel(col int) string {
 
 func cellRef(row, col int) string {
 	return columnLabel(col) + strconv.Itoa(row+1)
+}
+
+func (m model) colWidth(col int) int {
+	if w, ok := m.colWidths[col]; ok {
+		return w
+	}
+	return m.cellWidth
+}
+
+func (m model) maxContentWidthForCol(col int) int {
+	maxW := 4
+	for key, val := range m.cells {
+		if key.col != col {
+			continue
+		}
+		stripped, _, _, _ := parseCellFormatting(val)
+		w := runewidth.StringWidth(stripped)
+		if w > maxW {
+			maxW = w
+		}
+	}
+	return maxW
 }
 
 func clamp(value, low, high int) int {


### PR DESCRIPTION
- Enter: peek popup showing full cell value in centered overlay
- +/-: resize current column width only (per-column widths)
- =: auto-fit current column to widest content
- :fitall/:fa: auto-fit all columns at once
- Overlay uses ANSI-aware string manipulation (charmbracelet/x/ansi)
- Added 12 tests covering all new features

Out of transparancy: 
This is done mostly via AI, but tested with real data manually by me till satisfied.

Closes #20 