### PR TITLE
feat: add column fitting commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,17 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
+      - name: Run GoReleaser snapshot
+        if: github.event_name == 'pull_request'
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
+        if: github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Press <kbd>:</kbd> to open the command prompt, then use commands such as:
 - <kbd>:w</kbd> to save
 - <kbd>:w</kbd> <code>path.csv</code> to save to a new file
 - <kbd>:e</kbd> <code>path.csv</code> to open another CSV
+- <kbd>:fit</kbd> to fit the current column to its displayed contents
+- <kbd>:fit width</kbd> to fit visible columns to the current screen width
 - <kbd>:q</kbd> or <kbd>:wq</kbd> to quit
 - <kbd>:goto B9</kbd> or <kbd>:B9</kbd> to jump to a cell
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ Press <kbd>:</kbd> to open the command prompt, then use commands such as:
 - <kbd>:w</kbd> to save
 - <kbd>:w</kbd> <code>path.csv</code> to save to a new file
 - <kbd>:e</kbd> <code>path.csv</code> to open another CSV
-- <kbd>:fit</kbd> to fit the current column to its displayed contents
-- <kbd>:fit width</kbd> to fit visible columns to the current screen width
+- <kbd>:resize 20</kbd> to set the current column width explicitly
+- <kbd>:resize auto</kbd> or <kbd>:resize content</kbd> to fit the current column to its displayed contents
+- <kbd>:resize width</kbd> to fit visible columns to the current screen width
 - <kbd>:q</kbd> or <kbd>:wq</kbd> to quit
 - <kbd>:goto B9</kbd> or <kbd>:B9</kbd> to jump to a cell
 

--- a/internal/sheets/clipboard.go
+++ b/internal/sheets/clipboard.go
@@ -288,6 +288,7 @@ func (m *model) insertColAt(insertCol int) {
 	m.pushUndoState()
 
 	shifted := make(map[cellKey]string, len(m.cells))
+	shiftedWidths := make(map[int]int, len(m.colWidths))
 	for key, value := range m.cells {
 		newValue := rewriteFormulaForColInsert(value, insertCol)
 		if key.col < insertCol {
@@ -300,8 +301,20 @@ func (m *model) insertColAt(insertCol int) {
 		}
 		shifted[cellKey{row: key.row, col: newCol}] = newValue
 	}
+	for col, width := range m.colWidths {
+		if col < insertCol {
+			shiftedWidths[col] = width
+			continue
+		}
+		newCol := col + 1
+		if newCol >= totalCols {
+			continue
+		}
+		shiftedWidths[newCol] = width
+	}
 
 	m.cells = shifted
+	m.colWidths = shiftedWidths
 }
 
 func (m *model) insertRowAt(insertRow int) {

--- a/internal/sheets/commands.go
+++ b/internal/sheets/commands.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/charmbracelet/bubbles/cursor"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-runewidth"
 	"strings"
 	"unicode"
 )
@@ -125,7 +126,7 @@ func (m *model) executePrompt() tea.Cmd {
 		return tea.Quit
 	case strings.EqualFold(command, "help"),
 		strings.EqualFold(command, "?"):
-		m.commandMessage = "Commands: q, w, wq, x, goto <cell>, <cell>, e[dit] <path>, w[rite] [path]"
+		m.commandMessage = "Commands: q, w, wq, x, goto <cell>, <cell>, fit, fit width, e[dit] <path>, w[rite] [path]"
 		m.commandError = false
 		return nil
 	}
@@ -188,9 +189,70 @@ func (m *model) executePrompt() tea.Cmd {
 		return nil
 	}
 
+	if strings.EqualFold(name, "fit") {
+		switch {
+		case arg == "":
+			m.fitColumnToContent(m.selectedCol)
+			m.commandMessage = fmt.Sprintf("fit column %s", columnLabel(m.selectedCol))
+			m.commandError = false
+			m.ensureVisible()
+			return nil
+		case strings.EqualFold(arg, "width"):
+			m.fitVisibleColumnsToScreen()
+			m.commandMessage = "fit visible columns to screen"
+			m.commandError = false
+			m.ensureVisible()
+			return nil
+		default:
+			m.commandMessage = fmt.Sprintf("unknown fit target: '%s'", arg)
+			m.commandError = true
+			return nil
+		}
+	}
+
 	m.commandMessage = fmt.Sprintf("no such command: '%s'", command)
 	m.commandError = true
 	return nil
+}
+
+func (m *model) fitColumnToContent(col int) {
+	col = clamp(col, 0, totalCols-1)
+	width := runewidth.StringWidth(columnLabel(col))
+	for row := 0; row < m.rowCount; row++ {
+		width = max(width, runewidth.StringWidth(m.displayValue(row, col)))
+	}
+	m.setColumnWidth(col, width)
+}
+
+func (m *model) fitVisibleColumnsToScreen() {
+	visibleCols := m.visibleCols()
+	if visibleCols <= 0 {
+		return
+	}
+
+	usable := m.availableColumnWidth() - visibleCols
+	if usable < visibleCols*minCellWidth {
+		usable = visibleCols * minCellWidth
+	}
+	baseWidth := max(minCellWidth, usable/visibleCols)
+	extra := max(0, usable-baseWidth*visibleCols)
+	for i := 0; i < visibleCols; i++ {
+		width := baseWidth
+		if i < extra {
+			width++
+		}
+		m.setColumnWidth(m.colOffset+i, width)
+	}
+}
+
+func (m *model) setColumnWidth(col, width int) {
+	col = clamp(col, 0, totalCols-1)
+	width = max(minCellWidth, width)
+	if width == m.cellWidth {
+		delete(m.colWidths, col)
+		return
+	}
+	m.colWidths[col] = width
 }
 
 func splitCommandArgument(input string) (name, arg string) {

--- a/internal/sheets/commands.go
+++ b/internal/sheets/commands.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/bubbles/cursor"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-runewidth"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -126,7 +127,7 @@ func (m *model) executePrompt() tea.Cmd {
 		return tea.Quit
 	case strings.EqualFold(command, "help"),
 		strings.EqualFold(command, "?"):
-		m.commandMessage = "Commands: q, w, wq, x, goto <cell>, <cell>, fit, fit width, e[dit] <path>, w[rite] [path]"
+		m.commandMessage = "Commands: q, w, wq, x, goto <cell>, <cell>, resize <n|auto|content|width>, e[dit] <path>, w[rite] [path]"
 		m.commandError = false
 		return nil
 	}
@@ -189,23 +190,38 @@ func (m *model) executePrompt() tea.Cmd {
 		return nil
 	}
 
-	if strings.EqualFold(name, "fit") {
+	if strings.EqualFold(name, "resize") {
 		switch {
-		case arg == "":
+		case strings.EqualFold(arg, "auto"), strings.EqualFold(arg, "content"):
+			m.pushUndoState()
 			m.fitColumnToContent(m.selectedCol)
-			m.commandMessage = fmt.Sprintf("fit column %s", columnLabel(m.selectedCol))
+			m.commandMessage = fmt.Sprintf("resized column %s to content", columnLabel(m.selectedCol))
 			m.commandError = false
 			m.ensureVisible()
 			return nil
 		case strings.EqualFold(arg, "width"):
+			m.pushUndoState()
 			m.fitVisibleColumnsToScreen()
-			m.commandMessage = "fit visible columns to screen"
+			m.commandMessage = "resized visible columns to screen width"
 			m.commandError = false
 			m.ensureVisible()
 			return nil
-		default:
-			m.commandMessage = fmt.Sprintf("unknown fit target: '%s'", arg)
+		case arg == "":
+			m.commandMessage = "resize requires a width or mode"
 			m.commandError = true
+			return nil
+		default:
+			width, err := strconv.Atoi(arg)
+			if err != nil || width < minCellWidth {
+				m.commandMessage = fmt.Sprintf("invalid width: '%s'", arg)
+				m.commandError = true
+				return nil
+			}
+			m.pushUndoState()
+			m.setColumnWidth(m.selectedCol, width)
+			m.commandMessage = fmt.Sprintf("resized column %s to %d", columnLabel(m.selectedCol), width)
+			m.commandError = false
+			m.ensureVisible()
 			return nil
 		}
 	}

--- a/internal/sheets/edit_mode.go
+++ b/internal/sheets/edit_mode.go
@@ -172,7 +172,7 @@ func (m model) exitInsertMode() (tea.Model, tea.Cmd) {
 func (m model) renderEditingCell() string {
 	cursorModel := m.editCursor
 	cursorModel.TextStyle = lipgloss.NewStyle()
-	return renderTextInput(m.editingValue, m.editingCursor, m.cellWidth, cursorModel, lipgloss.NewStyle())
+	return renderTextInput(m.editingValue, m.editingCursor, m.columnWidth(m.selectedCol), cursorModel, lipgloss.NewStyle())
 }
 
 func (m *model) moveEditingCursor(delta int) {

--- a/internal/sheets/main_test.go
+++ b/internal/sheets/main_test.go
@@ -1653,21 +1653,40 @@ func TestCommandPromptUnknownCommandShowsMessage(t *testing.T) {
 	}
 }
 
-func TestCommandPromptFitSizesSelectedColumnToContent(t *testing.T) {
+func TestCommandPromptResizeSetsSelectedColumnWidth(t *testing.T) {
+	m := newModel()
+	m.mode = normalMode
+	m.selectedCol = 1
+
+	pending := startCommand(t, m, "resize 20")
+	got := applyKey(t, pending, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if got.commandError {
+		t.Fatalf("expected resize to succeed, got %q", got.commandMessage)
+	}
+	if got.commandMessage != "resized column B to 20" {
+		t.Fatalf("expected resize success message, got %q", got.commandMessage)
+	}
+	if got.columnWidth(1) != 20 {
+		t.Fatalf("expected resized width 20, got %d", got.columnWidth(1))
+	}
+}
+
+func TestCommandPromptResizeContentSizesSelectedColumnToContent(t *testing.T) {
 	m := newModel()
 	m.mode = normalMode
 	m.selectedCol = 1
 	m.setCellValue(0, 1, "short")
 	m.setCellValue(1, 1, "much longer value")
 
-	pending := startCommand(t, m, "fit")
+	pending := startCommand(t, m, "resize content")
 	got := applyKey(t, pending, tea.KeyMsg{Type: tea.KeyEnter})
 
 	if got.commandError {
-		t.Fatalf("expected fit to succeed, got %q", got.commandMessage)
+		t.Fatalf("expected resize content to succeed, got %q", got.commandMessage)
 	}
-	if got.commandMessage != "fit column B" {
-		t.Fatalf("expected fit success message, got %q", got.commandMessage)
+	if got.commandMessage != "resized column B to content" {
+		t.Fatalf("expected resize content success message, got %q", got.commandMessage)
 	}
 	if got.columnWidth(1) != len("much longer value") {
 		t.Fatalf("expected fitted width %d, got %d", len("much longer value"), got.columnWidth(1))
@@ -1677,21 +1696,21 @@ func TestCommandPromptFitSizesSelectedColumnToContent(t *testing.T) {
 	}
 }
 
-func TestCommandPromptFitWidthFillsVisibleScreenWidth(t *testing.T) {
+func TestCommandPromptResizeWidthFillsVisibleScreenWidth(t *testing.T) {
 	m := newModel()
 	m.mode = normalMode
 	m.width = 80
 	m.height = 24
 	visible := m.visibleCols()
 
-	pending := startCommand(t, m, "fit width")
+	pending := startCommand(t, m, "resize width")
 	got := applyKey(t, pending, tea.KeyMsg{Type: tea.KeyEnter})
 
 	if got.commandError {
-		t.Fatalf("expected fit width to succeed, got %q", got.commandMessage)
+		t.Fatalf("expected resize width to succeed, got %q", got.commandMessage)
 	}
-	if got.commandMessage != "fit visible columns to screen" {
-		t.Fatalf("expected fit width success message, got %q", got.commandMessage)
+	if got.commandMessage != "resized visible columns to screen width" {
+		t.Fatalf("expected resize width success message, got %q", got.commandMessage)
 	}
 	used := 0
 	for col := 0; col < visible; col++ {
@@ -1699,6 +1718,21 @@ func TestCommandPromptFitWidthFillsVisibleScreenWidth(t *testing.T) {
 	}
 	if used != got.availableColumnWidth() {
 		t.Fatalf("expected fitted columns to use %d cells, got %d", got.availableColumnWidth(), used)
+	}
+}
+
+func TestCommandPromptResizeRejectsInvalidWidth(t *testing.T) {
+	m := newModel()
+	m.mode = normalMode
+
+	pending := startCommand(t, m, "resize bogus")
+	got := applyKey(t, pending, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !got.commandError {
+		t.Fatal("expected invalid resize width to set command error")
+	}
+	if got.commandMessage != "invalid width: 'bogus'" {
+		t.Fatalf("expected invalid width message, got %q", got.commandMessage)
 	}
 }
 

--- a/internal/sheets/main_test.go
+++ b/internal/sheets/main_test.go
@@ -1653,6 +1653,55 @@ func TestCommandPromptUnknownCommandShowsMessage(t *testing.T) {
 	}
 }
 
+func TestCommandPromptFitSizesSelectedColumnToContent(t *testing.T) {
+	m := newModel()
+	m.mode = normalMode
+	m.selectedCol = 1
+	m.setCellValue(0, 1, "short")
+	m.setCellValue(1, 1, "much longer value")
+
+	pending := startCommand(t, m, "fit")
+	got := applyKey(t, pending, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if got.commandError {
+		t.Fatalf("expected fit to succeed, got %q", got.commandMessage)
+	}
+	if got.commandMessage != "fit column B" {
+		t.Fatalf("expected fit success message, got %q", got.commandMessage)
+	}
+	if got.columnWidth(1) != len("much longer value") {
+		t.Fatalf("expected fitted width %d, got %d", len("much longer value"), got.columnWidth(1))
+	}
+	if got.columnWidth(0) != got.cellWidth {
+		t.Fatalf("expected untouched column to keep default width %d, got %d", got.cellWidth, got.columnWidth(0))
+	}
+}
+
+func TestCommandPromptFitWidthFillsVisibleScreenWidth(t *testing.T) {
+	m := newModel()
+	m.mode = normalMode
+	m.width = 80
+	m.height = 24
+	visible := m.visibleCols()
+
+	pending := startCommand(t, m, "fit width")
+	got := applyKey(t, pending, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if got.commandError {
+		t.Fatalf("expected fit width to succeed, got %q", got.commandMessage)
+	}
+	if got.commandMessage != "fit visible columns to screen" {
+		t.Fatalf("expected fit width success message, got %q", got.commandMessage)
+	}
+	used := 0
+	for col := 0; col < visible; col++ {
+		used += got.columnWidth(col) + 1
+	}
+	if used != got.availableColumnWidth() {
+		t.Fatalf("expected fitted columns to use %d cells, got %d", got.availableColumnWidth(), used)
+	}
+}
+
 func TestCommandModeUsesPlainStatusStyle(t *testing.T) {
 	m := newModel()
 	m.mode = commandMode
@@ -3022,5 +3071,26 @@ func TestCellFromMouseMapping(t *testing.T) {
 	_, _, ok = m.cellFromMouse(borderX, 2)
 	if ok {
 		t.Fatal("expected click on column border to return false")
+	}
+}
+
+func TestCellFromMouseMappingWithCustomColumnWidths(t *testing.T) {
+	m := newModel()
+	m.width = 80
+	m.height = 24
+	m.setColumnWidth(0, 5)
+	m.setColumnWidth(1, 20)
+
+	x := m.rowLabelWidth + 2 + (m.columnWidth(0) + 1) + 7
+	y := 2
+	row, col, ok := m.cellFromMouse(x, y)
+	if !ok || row != 0 || col != 1 {
+		t.Fatalf("expected (0,1,true), got (%d,%d,%v)", row, col, ok)
+	}
+
+	borderX := m.rowLabelWidth + 2 + m.columnWidth(0)
+	_, _, ok = m.cellFromMouse(borderX, y)
+	if ok {
+		t.Fatal("expected click on custom-width column border to return false")
 	}
 }

--- a/internal/sheets/model.go
+++ b/internal/sheets/model.go
@@ -42,6 +42,7 @@ func newModel() model {
 		selectCol:     0,
 		cellWidth:     12,
 		rowLabelWidth: rowLabelWidthForCount(defaultRows),
+		colWidths:     make(map[int]int),
 		cells:         make(map[cellKey]string),
 		registers:     make(map[rune]clipboard),
 		marks:         make(map[rune]cellKey),
@@ -204,6 +205,7 @@ func (m *model) loadCSV(records [][]string) error {
 	m.markJumpPending = false
 	m.markJumpExact = false
 	m.selectRows = false
+	m.colWidths = make(map[int]int)
 	m.hasCopyBuffer = false
 	m.selectedRow = 0
 	m.selectedCol = 0
@@ -444,6 +446,7 @@ func (m *model) redoLastOperation() {
 func (m model) snapshotUndoState() undoState {
 	return undoState{
 		cells:       cloneCells(m.cells),
+		colWidths:   cloneColWidths(m.colWidths),
 		rowCount:    m.rowCount,
 		selectedRow: m.selectedRow,
 		selectedCol: m.selectedCol,
@@ -457,6 +460,7 @@ func (m model) snapshotUndoState() undoState {
 
 func (m *model) restoreUndoState(state undoState) {
 	m.cells = cloneCells(state.cells)
+	m.colWidths = cloneColWidths(state.colWidths)
 	m.rowCount = max(1, state.rowCount)
 	m.syncRowLabelWidth()
 	m.selectedRow = state.selectedRow
@@ -490,5 +494,11 @@ func (m *model) syncRowLabelWidth() {
 func cloneCells(cells map[cellKey]string) map[cellKey]string {
 	cloned := make(map[cellKey]string, len(cells))
 	maps.Copy(cloned, cells)
+	return cloned
+}
+
+func cloneColWidths(widths map[int]int) map[int]int {
+	cloned := make(map[int]int, len(widths))
+	maps.Copy(cloned, widths)
 	return cloned
 }

--- a/internal/sheets/navigate.go
+++ b/internal/sheets/navigate.go
@@ -97,12 +97,11 @@ func (m *model) ensureVisible() {
 		m.rowOffset = m.selectedRow - visibleRows + 1
 	}
 
-	visibleCols := m.visibleCols()
 	if m.selectedCol < m.colOffset {
 		m.colOffset = m.selectedCol
 	}
-	if m.selectedCol >= m.colOffset+visibleCols {
-		m.colOffset = m.selectedCol - visibleCols + 1
+	for m.lastVisibleCol() < m.selectedCol && m.colOffset < m.selectedCol {
+		m.colOffset++
 	}
 }
 
@@ -130,17 +129,44 @@ func (m model) halfPageRows() int {
 }
 
 func (m model) visibleCols() int {
-	available := m.width - m.rowLabelWidth - 2
-	if available <= m.cellWidth+1 {
+	available := m.availableColumnWidth()
+	if available <= 0 || m.colOffset >= totalCols {
 		return 1
 	}
 
-	cols := available / (m.cellWidth + 1)
-	if cols < 1 {
+	used := 0
+	visible := 0
+	for col := m.colOffset; col < totalCols; col++ {
+		width := m.columnWidth(col) + 1
+		if visible > 0 && used+width > available {
+			break
+		}
+		visible++
+		used += width
+		if used >= available {
+			break
+		}
+	}
+	if visible < 1 {
 		return 1
 	}
 
-	return min(cols, totalCols-m.colOffset)
+	return visible
+}
+
+func (m model) availableColumnWidth() int {
+	return max(0, m.width-m.rowLabelWidth-2)
+}
+
+func (m model) columnWidth(col int) int {
+	if width, ok := m.colWidths[col]; ok {
+		return max(minCellWidth, width)
+	}
+	return max(minCellWidth, m.cellWidth)
+}
+
+func (m model) lastVisibleCol() int {
+	return min(totalCols-1, m.colOffset+m.visibleCols()-1)
 }
 
 func (m model) firstNonBlankColumn(row int) int {
@@ -217,12 +243,21 @@ func (m model) cellFromMouse(x, y int) (row, col int, ok bool) {
 		return 0, 0, false
 	}
 
-	stride := m.cellWidth + 1
-	visibleColIndex := (x - cellAreaStart) / stride
-	offsetInStride := (x - cellAreaStart) % stride
-	if offsetInStride >= m.cellWidth || visibleColIndex >= m.visibleCols() {
-		return 0, 0, false
+	remaining := x - cellAreaStart
+	for visibleColIndex := 0; visibleColIndex < m.visibleCols(); visibleColIndex++ {
+		col = m.colOffset + visibleColIndex
+		width := m.columnWidth(col)
+		if remaining < width {
+			return m.rowOffset + visibleRowIndex, col, true
+		}
+		if remaining == width {
+			return 0, 0, false
+		}
+		remaining -= width + 1
+		if remaining < 0 {
+			return 0, 0, false
+		}
 	}
 
-	return m.rowOffset + visibleRowIndex, m.colOffset + visibleColIndex, true
+	return 0, 0, false
 }

--- a/internal/sheets/render.go
+++ b/internal/sheets/render.go
@@ -145,7 +145,7 @@ func (m model) renderColumnHeaders() string {
 
 	for i := 0; i < m.visibleCols(); i++ {
 		col := m.colOffset + i
-		label := alignCenter(columnLabel(col), m.cellWidth)
+		label := alignCenter(columnLabel(col), m.columnWidth(col))
 		if m.mode == selectMode && m.selectionContains(m.selectedRow, col) {
 			b.WriteString(m.activeHeaderStyle.Render(label))
 		} else if col == m.selectedCol {
@@ -190,9 +190,9 @@ func (m model) renderBorderLine(borderRow int, left, middle, right string, visib
 	b.WriteString(" ")
 	b.WriteString(m.renderBorderJunction(borderRow, m.colOffset, left))
 
-	segment := strings.Repeat("─", m.cellWidth)
 	for i := range visibleCols {
 		col := m.colOffset + i
+		segment := strings.Repeat("─", m.columnWidth(col))
 		b.WriteString(m.renderBorderSegment(borderRow, col, segment))
 		if i == visibleCols-1 {
 			b.WriteString(m.renderBorderJunction(borderRow, col+1, right))
@@ -221,7 +221,7 @@ func (m model) renderContentLine(row, visibleCols int) string {
 
 	for i := range visibleCols {
 		col := m.colOffset + i
-		cell := fit(m.displayValue(row, col), m.cellWidth)
+		cell := fit(m.displayValue(row, col), m.columnWidth(col))
 		formula := m.isFormulaDisplayCell(row, col)
 		formulaError := formula && m.isFormulaErrorDisplayCell(row, col)
 		raw := m.cellValue(row, col)

--- a/internal/sheets/types.go
+++ b/internal/sheets/types.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	defaultRows = 999
-	maxRows     = 50000
-	totalCols   = 52
+	defaultRows  = 999
+	maxRows      = 50000
+	totalCols    = 52
+	minCellWidth = 1
 )
 
 type mode string
@@ -44,6 +45,7 @@ const (
 
 type undoState struct {
 	cells       map[cellKey]string
+	colWidths   map[int]int
 	rowCount    int
 	selectedRow int
 	selectedCol int
@@ -143,6 +145,7 @@ type model struct {
 
 	cellWidth     int
 	rowLabelWidth int
+	colWidths     map[int]int
 
 	cells           map[cellKey]string
 	copyBuffer      clipboard


### PR DESCRIPTION
## Summary
- add per-column width support so rendering, editing, scrolling, and mouse selection can respect fitted columns
- add `:fit` to size the selected column to its displayed contents and `:fit width` to spread visible columns across the terminal width
- cover the new fitting behavior with command and mouse-hit tests, and document the commands in the README

## Testing
- `go test ./...`

Closes #20
Closes #21