### PR TITLE
Fix data loss bug when inserting column at last position

### DIFF
--- a/internal/sheets/clipboard.go
+++ b/internal/sheets/clipboard.go
@@ -281,8 +281,8 @@ func (m *model) pasteIntoCurrentCell(count int) bool {
 }
 
 func (m *model) insertColAt(insertCol int) {
-	insertCol = clamp(insertCol, 0, totalCols)
-	if insertCol >= totalCols {
+	insertCol = clamp(insertCol, 0, totalCols-1)
+	if insertCol >= totalCols-1 {
 		return
 	}
 	m.pushUndoState()


### PR DESCRIPTION
## Summary
This PR fixes a data loss bug that occurs when inserting a column at the last valid column position.

## Bug Description

When inserting a column at position `totalCols - 1` (which is column 51, labeled as "AZ"), cells at that column were shifted to position `totalCols` (column 52), which is out of bounds. This caused those cells to be silently dropped from the spreadsheet.

## Root Cause

In `internal/sheets/clipboard.go`, the `insertColAt` function:
1. Clamped `insertCol` to `[0, totalCols]` (allowed 52)
2. Checked `if insertCol >= totalCols` to return early
3. For cells at column 51 being shifted to column 52, the check `if newCol >= totalCols` would skip the cell

This meant that inserting at column 51 would cause data loss.

## Fix

Changed:
1. `clamp(insertCol, 0, totalCols)` → `clamp(insertCol, 0, totalCols-1)`
2. `if insertCol >= totalCols` → `if insertCol >= totalCols-1`

This prevents insertion at the last column position (51), avoiding the data loss scenario.

## Testing

To reproduce the original bug:
1. Create a spreadsheet with data in the last column (AZ/column 51)
2. Try to insert a column at position AZ
3. The data in column AZ would be lost

With this fix, the insert operation at the last column is prevented, preserving data integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)