### PR TITLE
chore: use `default` target and pin version to 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775305101,
+        "narHash": "sha256-/74n1oQPtKG52Yw41cbToxspxHbYz6O3vi+XEw16Qe8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "36a601196c4ebf49e035270e10b2d103fe39076b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,23 @@
 {
-  description = "sheets devshell and package";
+  description = "Flake for github:maaslalani/sheets";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
-      in {
+      in
+      {
         devShells.default = pkgs.mkShell {
           name = "sheets-devshell";
 
@@ -31,7 +38,10 @@
           vendorHash = "sha256-WWtAt0+W/ewLNuNgrqrgho5emntw3rZL9JTTbNo4GsI=";
 
           subPackages = [ "." ];
-          ldflags = [ "-s" "-w" ];
+          ldflags = [
+            "-s"
+            "-w"
+          ];
 
           meta = with pkgs.lib; {
             description = "Terminal based spreadsheet tool";
@@ -44,5 +54,6 @@
           type = "app";
           program = "${self.packages.${system}.default}/bin/sheets";
         };
-      });
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "sheets devshell and package";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
 
         apps.default = {
           type = "app";
-          program = "${self.packages.${system}.sheets}/bin/sheets";
+          program = "${self.packages.${system}.default}/bin/sheets";
         };
       });
 }


### PR DESCRIPTION
The output uses `default`, so accessing `sheets` doesn't make sense.

Also, `unstable` causes a ton of unnecessary cluttering in the `/nix/store`. Pin to the rolling release unless you need bleeding edge packages.