### PR TITLE
Reorganize the installation instructions, now including Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,28 +91,28 @@ Press <kbd>:</kbd> to open the command prompt, then use commands such as:
 
 ## Installation
 
-<!--
+### Go:
+
+```sh
+go install github.com/maaslalani/sheets@main
+```
 
 Use a package manager:
 
-```bash
-# macOS
-brew install sheets
+### Homebrew
 
+```bash
+brew install sheets
+```
+
+<!--
 # Arch
 yay -S sheets
 
 # Nix
 nix-env -iA nixpkgs.sheets
 ```
-
 -->
-
-Install with Go:
-
-```sh
-go install github.com/maaslalani/sheets@main
-```
 
 Or download a binary from the [releases](https://github.com/maaslalani/sheets/releases).
 


### PR DESCRIPTION
Sheets is now [available]() via [Homebrew](https://brew.sh).

I don't know the status of the other package managers, but for all I know, you might have written the respective packages for them as well 😉

_Scrolls.............._

Ack! This is already in #41, proceed as you see fit.