### PR TITLE
feat: add :sort and :sort! commands to sort by current column

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Press <kbd>:</kbd> to open the command prompt, then use commands such as:
 - <kbd>:e</kbd> <code>path.csv</code> to open another CSV
 - <kbd>:q</kbd> or <kbd>:wq</kbd> to quit
 - <kbd>:goto B9</kbd> or <kbd>:B9</kbd> to jump to a cell
+- <kbd>:sort</kbd> to sort by the current column ascending (row 1 treated as header, empty rows sink to bottom)
+- <kbd>:sort!</kbd> to sort descending
 
 ## Installation
 

--- a/internal/sheets/commands.go
+++ b/internal/sheets/commands.go
@@ -131,7 +131,7 @@ func (m *model) executePrompt() tea.Cmd {
 		return tea.Quit
 	case strings.EqualFold(command, "help"),
 		strings.EqualFold(command, "?"):
-		m.commandMessage = "Commands: q, w, wq, x, goto <cell>, <cell>, e[dit] <path>, w[rite] [path]"
+		m.commandMessage = "Commands: q, w, wq, x, goto <cell>, <cell>, e[dit] <path>, w[rite] [path], sort, sort!"
 		m.commandError = false
 		return nil
 	}
@@ -173,6 +173,12 @@ func (m *model) executePrompt() tea.Cmd {
 		m.commandMessage = fmt.Sprintf("wrote %s", arg)
 		m.commandError = false
 		m.dirtyFile = false
+		return nil
+	}
+
+	if strings.EqualFold(command, "sort") || command == "sort!" {
+		ascending := command != "sort!"
+		m.sortByColumn(m.selectedCol, ascending)
 		return nil
 	}
 

--- a/internal/sheets/sort.go
+++ b/internal/sheets/sort.go
@@ -1,0 +1,98 @@
+package sheets
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+func (m *model) sortByColumn(col int, ascending bool) {
+	if m.rowCount <= 1 {
+		return
+	}
+
+	const startRow = 1
+	numDataRows := m.rowCount - startRow
+	if numDataRows <= 0 {
+		return
+	}
+
+	// Single pass: mark non-empty rows and grab sort-column values.
+	nonEmptyRow := make([]bool, numDataRows)
+	for k := range m.cells {
+		if k.row >= startRow {
+			nonEmptyRow[k.row-startRow] = true
+		}
+	}
+
+	type sortKey struct {
+		f       float64
+		s       string
+		isFloat bool
+	}
+	keys := make([]sortKey, numDataRows)
+	for i := range keys {
+		v := m.cells[cellKey{row: startRow + i, col: col}]
+		f, err := strconv.ParseFloat(v, 64)
+		keys[i] = sortKey{f: f, s: v, isFloat: err == nil}
+	}
+
+	perm := make([]int, numDataRows)
+	for i := range perm {
+		perm[i] = i
+	}
+	sort.SliceStable(perm, func(a, b int) bool {
+		ia, ib := perm[a], perm[b]
+		if nonEmptyRow[ia] != nonEmptyRow[ib] {
+			return nonEmptyRow[ia]
+		}
+		var less bool
+		if keys[ia].isFloat && keys[ib].isFloat {
+			less = keys[ia].f < keys[ib].f
+		} else {
+			less = keys[ia].s < keys[ib].s
+		}
+		if ascending {
+			return less
+		}
+		return !less
+	})
+
+	// Inverse perm: inv[srcIdx] = destIdx — lets us remap in one map pass.
+	inv := make([]int, numDataRows)
+	for destIdx, srcIdx := range perm {
+		inv[srcIdx] = destIdx
+	}
+
+	// Swapping m.cells (not mutating) means oldCells is safe to store in undo
+	// without cloning — subsequent writes go to newCells, not oldCells.
+	newCells := make(map[cellKey]string, len(m.cells))
+	for k, v := range m.cells {
+		if k.row < startRow {
+			newCells[k] = v
+			continue
+		}
+		newCells[cellKey{row: startRow + inv[k.row-startRow], col: k.col}] = v
+	}
+
+	m.undoStack = append(m.undoStack, undoState{
+		cells:       m.cells,
+		rowCount:    m.rowCount,
+		selectedRow: m.selectedRow,
+		selectedCol: m.selectedCol,
+		selectRow:   m.selectRow,
+		selectCol:   m.selectCol,
+		selectRows:  m.selectRows,
+		rowOffset:   m.rowOffset,
+		colOffset:   m.colOffset,
+	})
+	m.redoStack = nil
+	m.cells = newCells
+
+	m.dirtyFile = true
+	direction := "ASC"
+	if !ascending {
+		direction = "DESC"
+	}
+	m.commandMessage = fmt.Sprintf("Sorted by column %s (%s)", columnLabel(col), direction)
+}


### PR DESCRIPTION
PR Description:
  ## Summary

  - New `:sort` command sorts data rows by the focused column ascending; `:sort!` sorts descending
  - Row 0 treated as header (excluded from sort); empty rows sink to bottom
  - Numeric values compared numerically, strings lexicographically
  - Sort is undoable via existing undo stack; marks file dirty
