### PR TITLE
Change normal button color to purple

### DIFF
--- a/internal/sheets/main_test.go
+++ b/internal/sheets/main_test.go
@@ -2590,13 +2590,13 @@ func TestEditCursorMatchesInsertModeColor(t *testing.T) {
 	}
 }
 
-func TestStatusModeColorsUseLegacyInsertAndNormalColors(t *testing.T) {
+func TestStatusModeColorsUseConfiguredModeColors(t *testing.T) {
 	m := newModel()
 
 	if got, want := m.statusInsertStyle.GetBackground(), lipgloss.Color("#D79921"); got != want {
 		t.Fatalf("expected insert status color %v, got %v", want, got)
 	}
-	if got, want := m.statusNormalStyle.GetBackground(), lipgloss.Color("33"); got != want {
+	if got, want := m.statusNormalStyle.GetBackground(), lipgloss.Color("13"); got != want {
 		t.Fatalf("expected normal status color %v, got %v", want, got)
 	}
 	if got, want := m.statusSelectStyle.GetBackground(), lipgloss.Color("13"); got != want {

--- a/internal/sheets/model.go
+++ b/internal/sheets/model.go
@@ -14,6 +14,7 @@ import (
 
 func newModel() model {
 	insertAccent := lipgloss.Color("#D79921")
+	normalAccent := lipgloss.Color("13")
 	selectAccent := lipgloss.Color("#2F66C7")
 	statusSelectAccent := lipgloss.Color("13")
 	formulaGreen := lipgloss.Color("2")
@@ -122,7 +123,7 @@ func newModel() model {
 			Background(statusGray).
 			Foreground(statusAccent),
 		statusNormalStyle: lipgloss.NewStyle().
-			Background(lipgloss.Color("33")).
+			Background(normalAccent).
 			Foreground(white).
 			Padding(0, 1),
 		statusInsertStyle: lipgloss.NewStyle().


### PR DESCRIPTION
## Summary
- Change the normal mode status button background from blue to purple.
- Keep the status mode color test aligned with the new normal mode color.

## Tests
- `go test ./...`

Fixes #60
