### PR TITLE
[feat] Increase max col and row

### DIFF
--- a/internal/sheets/types.go
+++ b/internal/sheets/types.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	defaultRows = 999
-	maxRows     = 50000
-	totalCols   = 52
+	maxRows     = 999999999
+	totalCols   = 676
 )
 
 type mode string


### PR DESCRIPTION
My reason for this PR is stated on my issue #53 
But this time around we had multiple question pools, which was then joined, and I couldn't view it without using MS365 Excel which needed internet. So I dug around and found out how I can increase the hard limits set.

- Increase the maximum column to 676
- Increase the maximum row to 999,999,999

Memory usage moved to roughly ~200 MiB after filling up to column 613 and row 88,374

Closes #53 